### PR TITLE
Fixes #39 - Check that default.library exists

### DIFF
--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -49,7 +49,13 @@ TestCase.prototype.resolveAnnotations = function(annotations) {
       include = annotations['venus-include'];
 
   if( !library ) {
-    library = config.get('default.library').value || 'mocha';
+    library = config.get('default.library').value;
+    if (!library) {
+      throw {
+        name: "LibraryException",
+        message: "The default library is not defined in .venus/config"
+      };
+    }
   } else if( Array.isArray(library) ) {
     library = library[0];
   }


### PR DESCRIPTION
If it doesn't exist, set it to mocha - if the library actually being used isn't Mocha, then the test will break, but at least it will break in a place where the tester will understand what's going on:

"Why is my qunit test trying to use Mocha? Oh, because I didn't specify qunit."
