### PR TITLE
Adding support for test server (the executor) to serve static content

### DIFF
--- a/.venus/config
+++ b/.venus/config
@@ -19,5 +19,10 @@
   // Default settings
   default: {
     library: 'mocha'
+  },
+
+  // Serve static content
+  static: {
+    sample: '../test/data/sample_tests'
   }
 }

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -18,7 +18,8 @@ var PORT        = 2013,
     _s          = require('underscore.string'),
     dust        = require('dustjs-linkedin'),
     pathHelper  = require('./util/pathHelper'),
-    config      = require('./config');
+    config      = require('./config'),
+    fstools    = require('fs-tools');
 
 /**
  * Test executor, responsible for running tests
@@ -34,15 +35,23 @@ function Executor() {
 /**
  * Initialize
  */
-Executor.prototype.init = function(config) {
+Executor.prototype.init = function(options) {
   var testgroup,
-      runners = this.runners = [];
+      runners = this.runners = [],
+      staticContent;
 
-  this.initEnvironment(config);
+  // prepare static content
+  staticContent = config.instance().get('static');
+
+  if(staticContent) {
+    this.prepStaticContent(staticContent);
+  }
+
+  this.initEnvironment(options);
 
   // Parse the list of relative paths specified in the command line arguments
   // in to an array of testcase objects.
-  testgroup = this.testgroup = testrun.create(this.parseTests(config.test));
+  testgroup = this.testgroup = testrun.create(this.parseTests(options.test));
 
   // If no tests were selected to run, there is nothing to do.
   // log an error and return.
@@ -54,20 +63,41 @@ Executor.prototype.init = function(config) {
 
   // If overlord option is selected, connect to overlord
   // defaults to not using an overlord.
-  if(config.overlord) {
-    logger.info( i18n('Connecting to Overlord - %s', config.overlord) );
-    this.connectOverlord(config.overlord, testgroup);
+  if(options.overlord) {
+    logger.info( i18n('Connecting to Overlord - %s', options.overlord) );
+    this.connectOverlord(options.overlord, testgroup);
   }
 
   // If phantomjs is selected, start the browsers.
-  if(config.phantom) {
+  if(options.phantom) {
     logger.verbose( i18n('Creating phantom runners') );
-    this.runners = runners.concat(this.createPhantomRunners(config));
+    this.runners = runners.concat(this.createPhantomRunners(options));
   }
 
   this.initRoutes();
   this.start(this.port);
   setTimeout(_.bind(function() { this.runTests(); }, this), 1000);
+}
+
+/**
+ * Copy static content to temp folder
+ */
+Executor.prototype.prepStaticContent = function(paths) {
+    var fspath, httpRoot, httpPath;
+
+    httpRoot = pathm.resolve(__dirname + '/../temp/static');
+
+    Object.keys(paths.value).forEach(function(key) {
+      fspath = pathm.resolve(path.dirname(paths.src) + '/' + paths.value[key]);
+      httpPath = pathm.resolve(httpRoot + '/' + key);
+
+      // copy the file
+      fstools.copy(fspath, httpPath, function(err) {
+        if(err) {
+          logger.error( i18n('error copying test file %s. exception: %s', httpPath, err) );
+        }
+      });
+    });
 }
 
 /**


### PR DESCRIPTION
To serve static content, add the 'static' property to a venus config file.

For example:

```
static: {
    mystuff: '../test/sample'
}
```

When the server starts, the contents of the `../test/sample` folder (path is relative to the config file), will be available at:

`http://hostname:port/temp/static/mystuff`
