### PR TITLE
Issue #55 - Create interface for adapters

### DIFF
--- a/.venus/adaptors/adaptor-template.js
+++ b/.venus/adaptors/adaptor-template.js
@@ -1,0 +1,168 @@
+/** 
+ * The template for Venus adapters
+ * Methods are defined in this class to help process and gather information about test results
+ * All adapters need to inherit this class and override methods as needed
+ * <xmp>
+ *  Adaptor.prototype = new AdaptorTemplate();
+ * </xmp>
+ * @class AdaptorTemplate
+ * @constructor
+ */
+function AdaptorTemplate() {
+
+  /**
+   * Enum object containing possible states for test result
+   * PASSED - test result passed
+   * FAILED - test result failed
+   */
+  this.ENUM_STATE = {
+    'PASSED' : 'PASSED',
+    'FAILED' : 'FAILED'
+  };
+
+  /**
+   * Object that contains test result information
+   * tests - list containing results for each test
+   * done  - object containing summary of test results
+   */
+  this.results = {
+    tests: [],
+    done: {}
+  };
+};
+
+/**
+ * Start and process test results
+ * NOTE: Override this method in adapter
+ * @method start
+ */
+AdaptorTemplate.prototype.start = function() {};
+
+/**
+ * Get message for test 
+ * NOTE: Override this method in adapter
+ * @method getTestMessage
+ * @param {Object} data Object containing results for test
+ * @returns {String} Test message
+ */
+AdaptorTemplate.prototype.getTestMessage = function(data) {
+  return '';
+};
+
+/**
+ * Get test name
+ * NOTE: Override this method in adapter
+ * @method getTestName
+ * @param {Object} data Object containing results for test
+ * @returns {String} Test name
+ */
+AdaptorTemplate.prototype.getTestName = function(data) {
+  return '';
+};
+
+/**
+ * Get status of test
+ * NOTE: Override this method in adapter
+ * @method getTestStatus
+ * @param {Object} data Object containing results for test
+ * @returns {String} Status
+ */
+AdaptorTemplate.prototype.getTestStatus = function(data) {
+  return this.ENUM_STATE.FAILED;
+};
+
+/**
+ * Get stack trace for test
+ * NOTE: Override this method in adapter
+ * @method getTestStackTrace
+ * @param {Object} data Object containing results for test
+ * @returns {String} Stack trace
+ */
+AdaptorTemplate.prototype.getTestStackTrace = function(data) {
+  return '';
+};
+
+/**
+ * Get total number of tests
+ * NOTE: Override this method in adapter
+ * @method getTotal
+ * @param {Object} data Object containing summary of test results
+ * @returns {Number} Total number of tests
+ */
+AdaptorTemplate.prototype.getTotal = function(data) {
+  return 0;
+};
+
+/**
+ * Get number of tests that failed
+ * NOTE: Override this method in adapter
+ * @method getTotalFailed
+ * @param {Object} data Object containing summary of test results
+ * @returns {Number} Number of tests that failed
+ */
+AdaptorTemplate.prototype.getTotalFailed = function(data) {
+  return 0;
+};
+
+/**
+ * Get number of tests that passed
+ * NOTE: Override this method in adapter
+ * @method getTotalPassed
+ * @param {Object} data Object containing summary of test results
+ * @returns {Number} Number of tests that passed
+ */
+AdaptorTemplate.prototype.getTotalPassed = function(data) {
+  return 0;
+};
+
+/**
+ * Get runtime of running all tests
+ * NOTE: Override this method in adapter
+ * @method getTotalRuntime
+ * @param {Object} data Object containing summary of test results
+ * @returns {Number} Runtime
+ */
+AdaptorTemplate.prototype.getTotalRuntime = function(data) {
+  return 0;
+};
+
+/**
+ * Process test result and add to list of test results
+ * @method addTestResult
+ * @param {Object} data Object containing results for test
+ */ 
+AdaptorTemplate.prototype.addTestResult = function(data) {
+  var test = {};
+
+  test = {
+    name: this.getTestName(data),
+    status: this.getTestStatus(data),
+    message: this.getTestMessage(data),
+    stackTrace: this.getTestStackTrace(data)
+  };
+
+  this.results.tests.push(test);
+};
+
+/**
+ * Process summary of test results
+ * @method processFinalResults
+ * @param {Object} data Object containing summary of test results
+ */ 
+AdaptorTemplate.prototype.processFinalResults = function(data) {
+
+  this.results.done = {
+    passed: this.getTotalPassed(data),
+    failed: this.getTotalFailed(data),
+    runtime: this.getTotalRuntime(data),
+    total: this.getTotal(data) 
+  };
+};
+
+/**
+ * Send test results to server
+ * @method sendResults
+ */ 
+AdaptorTemplate.prototype.sendResults = function() {
+  window.parent.venus.done(this.results);
+};

--- a/.venus/adaptors/qunit-venus.js
+++ b/.venus/adaptors/qunit-venus.js
@@ -1,42 +1,87 @@
-/**
- * Initialize a new QUnit adaptor
+/** 
+ * Create a QUnit adapter
+ * Inherits AdaptorTemplate class
+ * @class Adaptor
+ * @constructor
+ * @requires .venus/adapters/adaptor-template.js
  */
 function Adaptor() {}
 
 /**
- * Start the tests!
+ * Inherit AdaptorTemplate class
  */
-Adaptor.prototype.start = function() {
+Adaptor.prototype = new AdaptorTemplate();
 
-  var results = {
-    tests: [],
-    done: {}
-  };
+/**
+ * @override
+ */ 
+Adaptor.prototype.start = function() {
+  var self = this;
 
   // QUnit calback - log
   QUnit.log(function(data) {
-
-    // Retrieve test
-    var test = {
-      name: data.name,
-      status: data.result === true ? 'PASSED' : 'FAILED',
-      message: data.message ? data.message : '',
-      stackTrace: data.source ? data.source : ''
-    };
-    results.tests.push(test);
+    self.addTestResult(data);
   });
 
   // QUnit calback - done
   QUnit.done(function(data) {
-
-    // Retrieve final test results
-    results.done =  {
-      passed: data.passed,
-      failed: data.failed,
-      runtime: data.runtime,
-      total: data.total
-    };
-
-    window.parent.venus.done(results);
+    self.processFinalResults(data);
+    self.sendResults();
   });
+};
+
+/**
+ * @override
+ */
+Adaptor.prototype.getTestMessage = function(data) {
+  return data.message ? data.message : '';
+};
+
+/**
+ * @override
+ */
+Adaptor.prototype.getTestName = function(data) {
+  return data.name;
+};
+
+/**
+ * @override
+ */
+AdaptorTemplate.prototype.getTestStatus = function(data) {
+  return data.result === true ? this.ENUM_STATE.PASSED : this.ENUM_STATE.FAILED;
+};
+
+/**
+ * @override
+ */
+AdaptorTemplate.prototype.getTestStackTrace = function(data) {
+  return data.source ? data.source : ''
+};
+
+/**
+ * @override
+ */
+AdaptorTemplate.prototype.getTotal = function(data) {
+  return data.total;
+};
+
+/**
+ * @override
+ */
+AdaptorTemplate.prototype.getTotalFailed = function(data) {
+  return data.failed;
+};
+
+/**
+ * @override
+ */
+AdaptorTemplate.prototype.getTotalPassed = function(data) {
+  return data.passed;
+};
+
+/**
+ * @override
+ */
+AdaptorTemplate.prototype.getTotalRuntime = function(data) {
+  return data.runtime;
 };

--- a/.venus/config
+++ b/.venus/config
@@ -5,12 +5,14 @@
       includes: [
         'libraries/mocha.js',
         'libraries/expect.js',
+        'adaptors/adaptor-template.js',
         'adaptors/mocha-venus.js'
       ]
     },
     qunit: {
       includes: [
         'libraries/qunit.js',
+        'adaptors/adaptor-template.js',
         'adaptors/qunit-venus.js'
       ]
     }


### PR DESCRIPTION
I created the template for all Venus adapters.

The file for the template will be located in the following file path: `.venus/adaptors/adaptor-template.js`

Whenever a new adapter is created, it should inherit the template via prototype
`Adaptor.prototype = new AdaptorTemplate();`

Once the template has been inherited, the adapter should override methods defined in the template to process the test results 

I documented and annotated the files to provide further explanation

The following adaptors have been updated using the template:
- QUnit
- Mocha

I also updated the config file under the .venus directory to add the template JS file to the test fixture page
