### PR TITLE
Removes jQuery dependency for venus runner_client

### DIFF
--- a/js/runner_client/venus.js
+++ b/js/runner_client/venus.js
@@ -3,7 +3,30 @@
 
   function Venus() {}
 
+  var XHR = (function() {
+    var ids = ["Msxml2.XMLHTTP", "Microsoft.XMLHTTP", "Msxml2.XMLHTTP.4.0"];
+    if (typeof XMLHttpRequest !== "undefined") {
+      return XMLHttpRequest;
+    }
+
+    for (var i = 0; i < ids.length; i++) {
+      try {
+        new ActiveXObject(ids[i]);
+        return function() {
+          return new ActiveXObject(ids[i]);
+        };
+        break;
+      } catch (e) {}
+    }
+  })();
+
   Venus.prototype.done = function(results) {
-    $.post(window.venus.postUrl, JSON.stringify(results));
+    var xmlhttp = new XHR();
+    var result = JSON.stringify(results);
+    xmlhttp.open("POST", window.venus.postUrl, true);
+    xmlhttp.setRequestHeader("Content-type","application/x-www-form-urlencoded");
+    xmlhttp.setRequestHeader("Content-length", result.length);
+    xmlhttp.setRequestHeader("Connection", "close");
+    xmlhttp.send(result);
   };
 }(window));


### PR DESCRIPTION
There's no need to load jQuery just for $.post. This also makes it possible to avoid an accidentally leaked jQuery global
