### PR TITLE
Allow test include paths to contain dashes

### DIFF
--- a/lib/util/commentsParser.js
+++ b/lib/util/commentsParser.js
@@ -64,7 +64,7 @@ function parseBlock (block) {
  * Parse a param
  */
 function parseParam (param) {
-  var kvRegex     = /([\w-]+)\s+([\s\w/-~_\.\"]+)?/,
+  var kvRegex     = /([\w-]+)\s+([\s\w/-~_\.\"\-]+)?/,
       kvMatches   = param.match(kvRegex),
       name        = kvMatches[1],
       value       = kvMatches[2];

--- a/test/data/sample_tests/paths_with_dashes.js
+++ b/test/data/sample_tests/paths_with_dashes.js
@@ -1,0 +1,5 @@
+/**
+ * @venus-include ../test-file.js
+ * @venus-include foo--foo.js
+ * @venus-include bar.js
+ */

--- a/test/specs/testcase.js
+++ b/test/specs/testcase.js
@@ -89,6 +89,27 @@ describe('lib/testcase', function() {
 
     });
 
+    it('should work with paths containing dashes', function() {
+      var testpath = testHelper.sampleTests('paths_with_dashes.js'),
+          conf     = testHelper.testConfig(),
+          test     = new testcase.TestCase(conf),
+          files;
+
+      test.path = testpath;
+      test.directory = testHelper.sampleTests();
+      test.id = 1;
+      files = test.prepareIncludes(
+        test.resolveAnnotations(
+          test.parseTestFile(testpath).annotations
+      ));
+
+      should.exist(files);
+      files.should.be.an.instanceOf(Array);
+      files[4].url.should.eql('/temp/test/1/includes/test-file.js');
+      files[4].fs.should.contain('/test/data/test-file.js');
+
+    });
+
     it('should load universal includes', function() {
       var testpath = testHelper.sampleTests('relative_paths.js'),
           conf     = testHelper.testConfig(),

--- a/test/specs/util/commentsParser.js
+++ b/test/specs/util/commentsParser.js
@@ -75,6 +75,16 @@ describe('lib/util/commentsParser', function() {
       ' */ \n'
     ].join('');
 
+    //  /**
+    //   * @venus-include ../www/test-file.js
+    //   */
+    var commentsG = [
+        '/**\n',
+        ' * @venus-include ../www/test-file.js \n',
+        ' */'
+      ].join('');
+
+
     it('should handle an empty file', function() {
       var annotations = parser.parseStr(commentsD);
       should.exist(annotations);
@@ -129,6 +139,16 @@ describe('lib/util/commentsParser', function() {
       should.exist(annotations);
       should.exist(annotations[annotation.VENUS_INCLUDE]);
       annotations[annotation.VENUS_INCLUDE].should.eql('~/var/foo_test.js');
+
+    });
+
+    it('should parse file paths with dashes correctly', function() {
+      var comments = buildCommentBlock('@venus-include ~/var/test-file.js'),
+          annotations = parser.parseStr(comments);
+
+      should.exist(annotations);
+      should.exist(annotations[annotation.VENUS_INCLUDE]);
+      annotations[annotation.VENUS_INCLUDE].should.eql('~/var/test-file.js');
 
     });
 


### PR DESCRIPTION
Closes issue #86 - parse testcase includes with paths containing dashes. Also added new specs to ensure we do not regress in the future.
