### PR TITLE
Support for @venus-includes with same filenames (but different paths)

### DIFF
--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -118,7 +118,7 @@ TestCase.prototype.resolveAnnotations = function(annotations) {
 
 /**
  * Prepare testcase includes - there are the files
- * to be included on the test fixture page in the browser
+ * to be included on the test harness page in the browser
  */
 TestCase.prototype.prepareIncludes = function(annotations) {
   var library = annotations[annotation.VENUS_LIBRARY],
@@ -136,7 +136,7 @@ TestCase.prototype.prepareIncludes = function(annotations) {
       includeFiles = annotations[annotation.VENUS_INCLUDE],
       includeGroups = annotations[annotation.VENUS_INCLUDE_GROUP];
 
-  httpRoot = pathm.resolve(__dirname + '/../temp/test/' + testId);
+  httpRoot = pathm.resolve(__dirname, '..', 'temp', 'test', testId.toString() );
   httpResourceUrls = [];
 
   includes = config.resolve('libraries.' + library + '.includes')
@@ -160,31 +160,53 @@ TestCase.prototype.prepareIncludes = function(annotations) {
   }
 
   includes = includes.map(function(include) {
-    return { path: include, httpDir: 'lib' };
+    return { path: include, httpDir: 'lib', prepend: '' };
   });
+
+  var dupeList = [];
 
   // Add files specified with @venus-include annotations
   includeFiles.forEach(function(filePath) {
+    var filename = pathHelper(filePath).file,
+        prepend  = '',
+        parts;
+
+    if( dupeList.indexOf(filename) !== -1 ){
+      // avoid dupe
+      parts = filePath.split('/');
+      parts.forEach( function( part, index ){
+        if( index == parts.length - 1 ) {
+          return;
+        }
+
+        if( part === '..' ){
+          prepend += '__';
+        } else if(part) {
+          prepend += part + '__';
+        }
+      } );
+    }
 
     // if path doesn't begin with a '/' character, we assume it
     // is relative and needs to be resolved relative
     // to the directory the testcase file lives in
-    if(filePath[0] !== '/') {
+    if( filePath[0] !== '/' ){
       filePath = pathm.resolve( this.directory + '/' + filePath );
     }
 
-    includes.push({ path: filePath, httpDir: 'includes' });
+    dupeList.push(filename);
+    includes.push({ prepend: prepend, path: filePath, httpDir: 'includes' });
   }, this);
 
   // Add the testcase file
-  includes.push({ path: this.path, httpDir: 'test' });
+  includes.push({ path: this.path, httpDir: 'test', prepend: '' });
 
   // Take list of files to be included and copy them to a temporary location
   // on the server. The path is {venus install location}/temp/test/{testid}/includes
   includes.forEach(function(include) {
     var filePath    = include.path,
         httpDir     = include.httpDir,
-        destination = pathm.resolve(httpRoot + '/' + httpDir + '/' + pathHelper(filePath).file),
+        destination = pathm.resolve(httpRoot + '/' + httpDir + '/' + include.prepend + pathHelper(filePath).file),
         httpUrl     = '/' + destination.substr( destination.indexOf('temp/test/'+testId) );
 
     // Add to list of file mappings

--- a/test/data/sample_tests/dupe_filenames.js
+++ b/test/data/sample_tests/dupe_filenames.js
@@ -1,0 +1,5 @@
+/**
+ * @venus-include fileA.js
+ * @venus-include ../fileA.js
+ * @venus-include ../prod/fileA.js
+ */

--- a/test/specs/testcase.spec.js
+++ b/test/specs/testcase.spec.js
@@ -166,5 +166,27 @@ describe('lib/testcase', function() {
       files.should.be.an.instanceOf(Array);
       files[4].url.should.eql('/temp/test/1/lib/file3.js');
     });
+
+    it('should handle different paths with same filename', function() {
+      var testpath = testHelper.sampleTests('dupe_filenames.js'),
+          conf     = testHelper.testConfig(),
+          test     = new testcase.TestCase(conf),
+          files;
+
+      test.path = testpath;
+      test.directory = testHelper.sampleTests();
+      test.id = 1;
+      files = test.prepareIncludes(
+        test.resolveAnnotations(
+          test.parseTestFile(testpath).annotations
+      ));
+
+      should.exist(files);
+      files[4].url.should.eql('/temp/test/1/includes/fileA.js');
+      files[5].url.should.eql('/temp/test/1/includes/__fileA.js');
+      files[6].url.should.eql('/temp/test/1/includes/__prod__fileA.js');
+      //files.should.be.an.instanceOf(Array);
+      //files[4].url.should.eql('/temp/test/1/lib/file3.js');
+    });
   });
 });


### PR DESCRIPTION
/**
- @venus-include fileA.js
- @venus-include ../../fileA.js
- @venus-include ../../src/fileA.js
  */

`../../fileA.js` becomes `____fileA.js`
`../../src/fileA.js` becomes `____src__fileA.js`
