### PR TITLE
Re-enable killing Venus after test results are printed on CLI.

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -455,6 +455,10 @@ Executor.prototype.start = function(port, onStart) {
           } else {
             done({ status: 'ok' });
           }
+
+          setTimeout(function() {
+            process.exit(1);
+          }, 1000);
         });
 
         socket.on('console.log', function(data, done) {


### PR DESCRIPTION
This regressed with socket.io change.
