### PR TITLE
Fixes issue #124, namespace URL path to Venus resources.

### DIFF
--- a/.venus/templates/default.tl
+++ b/.venus/templates/default.tl
@@ -15,7 +15,7 @@
 </head>
 <body>
   check your console for test results
-  <iframe src="/test/sandbox/{testId}" id="sandbox">
+  <iframe src="{testSandboxUrl}" id="sandbox">
   <!--Running test: {testId}-->
 </body>
 </html>

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -35,6 +35,7 @@ function Executor() {
   this.runners = [];
   this.port;
   this.socket;
+  this.urlNamespace = '/venus-core';
 };
 
 // Initialize
@@ -246,7 +247,7 @@ Executor.prototype.parseTestPaths = function(testPaths, testObjects) {
        test = testcase.create(
          path,
          testId,
-         'http://' + hostname + ':' + this.port + '/test/' + testId);
+         'http://' + hostname + ':' + this.port + this.urlNamespace + '/' + testId);
 
        testObjects[testId] = test;
      } else {
@@ -320,7 +321,7 @@ Executor.prototype.initRoutes = function() {
   });
 
   /** Serves the sandbox page **/
-  app.get('/test/sandbox/:testid', function(request, response) {
+  app.get(this.urlNamespace + '/sandbox/:testid', function(request, response) {
     var tests = exec.testgroup.tests,
         testId = request.params.testid,
         test  = tests[testId],
@@ -371,7 +372,7 @@ Executor.prototype.initRoutes = function() {
   });
 
   // Serves the page that will render the sandbox in an iframe
-  app.get('/test/:testid', function(request, response) {
+  app.get(this.urlNamespace + '/:testid', function(request, response) {
     var tests = exec.testgroup.tests,
     testId = request.params.testid,
     test  = tests[testId],
@@ -388,7 +389,8 @@ Executor.prototype.initRoutes = function() {
 
     // Set template data, and render the Dust template
     templateData = {
-      postTestResultsUrl: '/test/results/' + testId,
+      postTestResultsUrl: exec.urlNamespace + '/results/' + testId,
+      testSandboxUrl: exec.urlNamespace + '/sandbox/' + testId,
       testId: testId
     };
     harnessTemplate = config.instance().loadTemplate('default');
@@ -405,7 +407,7 @@ Executor.prototype.initRoutes = function() {
   });
 
   /** Receive results for a test **/
-  app.post('/test/results/:testid', function(request, response) {
+  app.post(this.urlNamespace + '/results/:testid', function(request, response) {
     var testId = request.params.testid,
     test = tests[testId];
 


### PR DESCRIPTION
Venus resources will now be served from `localhost:PORT/venus-core`, instead of `localhost:PORT/test`.
