### PR TITLE
Adding default phantomjs path to config

### DIFF
--- a/.venus/config
+++ b/.venus/config
@@ -33,9 +33,9 @@
   },
 
   // Binaries
-  // binaries: {
-  //  phantomjs: '/path/to/phantomjs'
-  // }
+  binaries: {
+    phantomjs: '../bin/phantomjs'
+  }
 
   // Serve static content
   //static: {

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -171,6 +171,10 @@ Executor.prototype.createPhantomRunners = function( options ) {
     }
   }
 
+  if (!fs.existsSync(phantomPath)) {
+    phantomPath = null;
+  }
+
   logger.verbose( i18n('Creating phantomjs UACs') );
 
   if( phantomPath ){


### PR DESCRIPTION
Adding default phantomjs path to point to  app bin directory. If this binary doesn't exist, fall back to looking for phantomjs in system path.
