### PR TITLE
Changing syntax to specify selenium browser version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.10
+
+-- Updated syntax for running tests with selenium webdriver. New syntax: `venus run -t spec.js --selenium grid_url --browser chrome|20.0`
+-- Changed test urls to use system IP address instead of hostname. Can manually set hostname with either `--hostname` command line flag, or `hostname: 'myhost'` property in config file
+
 ## 1.0.9
 
 -- Venus is now smarter about finding the right path for phantomjs

--- a/Venus.js
+++ b/Venus.js
@@ -98,15 +98,18 @@ Venus.prototype.init = function (args) {
     .option('-t, --test [tests]', i18n('Comma separated string of tests to run'))
     .option('-p, --port [port]', i18n('port to run on'), function (value) { return parseInt(value, 10); })
     .option('-n, --phantom [path to binary]', i18n('Use phantomJS client to run browser tests'))
-    .option('-s, --selenium', i18n('Use selenium client to run browser tests'))
-    .option('-r, --selenium-server [url]', i18n('Specify selenium server to use'))
-    .option('-b, --selenium-browser [browser]', i18n('Specify browser to use with selenium'))
+    .option('-s, --selenium [server url]', i18n('Use selenium client to run browser tests'))
+    .option('--browser [browser|version]', i18n('Browser name to request from selenium webdriver'))
     .option('-l, --locale [locale]', i18n('Specify locale to use'))
     .option('-v, --verbose', i18n('Run in verbose mode'))
     .option('-d, --debug', i18n('Run in debug mode'))
     .option('-c, --coverage', i18n('Generate Code Coverage Report'))
     .option('--hostname', i18n('Set hostname for test URLs, defaults to your ip address'))
     .option('--require-annotations', i18n('Ignore JavaScript test files which do not contain a Venus annotation (@venus-*)'))
+
+    .option('-r, --selenium-server [url]', i18n('[deprecated] Specify selenium server to use'))
+    .option('-b, --selenium-browser [browser]', i18n('[deprecated] Specify browser to use with selenium'))
+
     .action(_.bind(this.command(this.run), this));
 
   program.parse(args);

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -207,9 +207,24 @@ Executor.prototype.createCasperRunners = function() {
  * Create selenium runners
  */
 Executor.prototype.createSeleniumRunners = function( options ){
-  var browserName = options.seleniumBrowser || options.browser || this.config.get('selenium.browser').value || 'firefox',
-      server = options.seleniumServer || options.selenium,
-      version = options.version || this.config.get('selenium.version').value;
+  var browserName, server, version;
+
+  if (options.seleniumBrowser) {
+    browserName = options.seleniumBrowser;
+  } else if (options.browser) {
+    browserName = options.browser.split('|')[0];
+    version = options.browser.split('|')[1];
+  } else if (this.config.get('selenium.browser')) {
+    browserName = this.config.get('selenium.browser').value;
+  } else {
+    browserName = 'firefox';
+  }
+
+  if (!version && this.config.get('selenium.version')) {
+    version = this.config.get('selenium.version').value;
+  }
+
+  server = options.seleniumServer || options.selenium,
 
   logger.verbose( i18n('Creating selenium uacs') );
   logger.verbose( i18n('Server: ' + server) );

--- a/locales/pirate.js
+++ b/locales/pirate.js
@@ -92,5 +92,14 @@
 	"Browser: [object Object]": "Browser: [object Object]",
 	"Browser: netscape": "Browser: netscape",
 	"Browser: foobar": "Browser: foobar",
-	"Set hostname for test URLs, defaults to your ip address": "Set hostname for test URLs, defaults to your ip address"
+	"Set hostname for test URLs, defaults to your ip address": "Set hostname for test URLs, defaults to your ip address",
+	"Browser name to request from selenium webdriver": "Browser name to request from selenium webdriver",
+	"Browser version to request from selenium webdriver": "Browser version to request from selenium webdriver",
+	"[deprecated] Specify selenium server to use": "[deprecated] Specify selenium server to use",
+	"[deprecated] Specify browser to use with selenium": "[deprecated] Specify browser to use with selenium",
+	"Browser: internet explorer": "Browser: internet explorer",
+	"Browser: internet explorer|9.0": "Browser: internet explorer|9.0",
+	"Browser: chrome|21.0": "Browser: chrome|21.0",
+	"Server: undefined": "Server: undefined",
+	"Browser: chromeoid": "Browser: chromeoid"
 }

--- a/test/specs/executor.spec.js
+++ b/test/specs/executor.spec.js
@@ -109,20 +109,19 @@ describe('lib/executor', function() {
 
     options = {
       selenium: 'ioi.net',
-      browser: 'chrome',
-      version: '21',
+      browser: 'chromeoid|21.0',
       test: test
     };
 
     exec.init(options);
     runner = exec.runners[0];
 
-    it('should use chrome', function () {
-      runner.client.desiredCapabilities.browserName.should.eql('chrome');
+    it('should use chromeoid', function () {
+      runner.client.desiredCapabilities.browserName.should.eql('chromeoid');
     });
 
     it('should use version 21', function () {
-      runner.client.desiredCapabilities.version.should.eql('21');
+      runner.client.desiredCapabilities.version.should.eql('21.0');
     });
 
     it('should connect to ioi.net', function () {


### PR DESCRIPTION
Simplifying syntax to run tests with selenium webdriver.

Old syntax:

`venus run --test spec.js --selenium --selenium-server 192.0.0.101 --selenium-browser chrome`

New syntax:

`venus run --test spec.js --selenium 192.0.0.101 --browser chrome`

Additionally, you can now specify browser version:

`venus run --test spec.js --selenium 192.0.0.101 --browser chrome|20.0`

The old syntax still works, for backwards compatibility.
