### PR TITLE
Fix issue with rendering Venus test list page

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -513,9 +513,11 @@ Executor.prototype.handleResultsPage = function(request, response) {
  * @param {Object} response Response object
  */
 Executor.prototype.handleIndexPage = function(request, response) {
-  var data = { tests: [] };
-  Object.keys( this.testgroup.tests ).forEach( function( key ){
-    data.tests.push( tests[key] );
+  var data  = { tests: [] },
+      tests = this.testgroup.tests;
+
+  Object.keys(tests).forEach(function (key) {
+    data.tests.push(tests[key]);
   });
   response.render( 'executor/index', data );
 };
@@ -543,12 +545,11 @@ Executor.prototype.processRoute = function (routeFile) {
 
 Executor.prototype.initRoutes = function() {
   var routes = this.config.get('routes'),
-  port = this.port,
-  app  = this.app,
-  routeKey;
+      app  = this.app,
+      routeKey;
 
   /** Index **/
-  app.get('/', this.handleIndexPage);
+  app.get('/', this.handleIndexPage.bind(this));
 
   // Set up routes explicitly defined in the config.
   if (routes) {


### PR DESCRIPTION
Due to some previous refactoring, the root server page (which lists all loaded test cases), was throwing an exception.
