### PR TITLE
PhantomJS path resolution fix

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -206,6 +206,11 @@ module.exports.parseConfigFile = function (filePath) {
     data.basePaths[index] = path.resolve(configFileDirectory, data.basePaths[index]);
   }
 
+  // Binary paths
+  for (index in data.binaries) {
+    data.binaries[index] = path.resolve(configFileDirectory, data.binaries[index]);
+  }
+
   // Includes
   if (typeof data.includes === 'object') {
     Object.keys(data.includes).forEach(function (index) {

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -175,8 +175,8 @@ Executor.prototype.createPhantomRunners = function( options ) {
   }
 
   if( !phantomPath ){
-    if (this.config.binaries && this.config.phantomjs) {
-      phantomPath = this.config.binaries.phantomjs;
+    if (this.config.get('binaries.phantomjs')) {
+      phantomPath = this.config.get('binaries.phantomjs');
     }
   }
 


### PR DESCRIPTION
Fixed bug where path to phantomjs in config file was not properly being resolved, causing running tests with phantomjs to fail in some cases.
