### PR TITLE
Fix backward compatibility of config file...

### DIFF
--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -195,7 +195,7 @@ TestCase.prototype.prepareIncludes = function (annotations) {
   httpResourceUrls = [];
 
   // Add library files
-  includes = config.get('libraries', library, 'includes');
+  includes = config.get('libraries', library, 'includes') || [];
 
   // Add default includes
   // I dont understand these configurations. What do they do?????


### PR DESCRIPTION
Venus 1.1.3 crashes on startup when using certain config files that work ok with 1.1.1.

I think the code was assuming that the config always contains:

```
{
   libraries: {includes: []}
}
```

whereas my config contained:

```
{
   libraries: {}
}
```

Keeping a simple default empty config seems desirable: this commit makes a tiny change to be ok when the nested `includes` is missing.
