### PR TITLE
Migrate from should.js to expect.js assertion library for Venus tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,7 @@
     "flavored-path"          : "0.0.8"
   },
   "devDependencies": {
-    "chai"              : "1.0.4",
     "mocha"             : "1.2.0",
-    "sinon-chai"        : "2.1.2",
     "sinon"             : "1.3.4"
   },
   "os": ["!win32"],

--- a/test/unit/Binary.spec.js
+++ b/test/unit/Binary.spec.js
@@ -1,9 +1,7 @@
 /**
  * @author LinkedIn
  */
-var should    = require('../lib/sinon-chai').chai.should(),
-    sinon     = require('sinon'),
-    spawn     = require('child_process').spawn,
+var spawn     = require('child_process').spawn,
     path      = require('path');
 
 describe('Venus binary', function() {

--- a/test/unit/Venus.spec.js
+++ b/test/unit/Venus.spec.js
@@ -1,15 +1,15 @@
 /**
  * @author LinkedIn
  */
-var should    = require('../lib/sinon-chai').chai.should(),
+var expect    = require('expect.js'),
     sinon     = require('sinon'),
     Venus     = require('../../Venus');
 
 describe('Venus main', function() {
   it('should instantiate', function() {
     var venus = new Venus();
-    should.exist(venus);
-    (venus instanceof Venus).should.be.true;
+    expect(venus).to.be.ok();
+    expect(venus).to.be.a(Venus);
   });
 
   it('should call run when run command is passed', function() {
@@ -18,7 +18,7 @@ describe('Venus main', function() {
 
     app.run = sinon.spy();
     app.start(argv);
-    app.run.should.have.been.calledOnce;
+    expect(app.run.calledOnce).to.be(true);
   });
 
   it('should initialize a new project when init command is passed', function() {
@@ -27,6 +27,6 @@ describe('Venus main', function() {
 
     app.initProjectDirectory = sinon.spy();
     app.start(argv);
-    app.initProjectDirectory.should.have.been.calledOnce;
+    expect(app.initProjectDirectory.calledOnce).to.be(true);
   });
 });

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -2,13 +2,9 @@
  * @author LinkedIn
  */
 'use strict';
-var should        = require('../lib/sinon-chai').chai.should(),
-    config        = require('../../lib/config'),
+var config        = require('../../lib/config'),
     sinon         = require('sinon'),
-    fsHelper      = require('../../lib/util/fsHelper'),
-    fs            = require('fs'),
     path          = require('flavored-path'),
-    pathHelper    = require('../../lib/util/pathHelper'),
     expect        = require('expect.js'),
     testHelper    = require('../lib/helpers.js');
 
@@ -46,7 +42,7 @@ describe('lib/config', function() {
       mock.expects('loadFile').once().withExactArgs('templates/test.tl')
           .returns('content');
 
-      config.loadTemplate('test').should.eql('content');
+      expect(config.loadTemplate('test')).to.be('content');
 
       mock.verify();
     });

--- a/test/unit/constants.spec.js
+++ b/test/unit/constants.spec.js
@@ -2,17 +2,16 @@
  * @author LinkedIn
  */
 'use strict';
-var should        = require('../lib/sinon-chai').chai.should(),
-    constants     = require('../../lib/constants'),
-    testHelper    = require('../lib/helpers');
+var expect        = require('expect.js'),
+    constants     = require('../../lib/constants');
 
 describe('lib/constants', function () {
 
   it('should load correct interface', function () {
     var networkInterface = constants.getInterface();
 
-    networkInterface.internal.should.be.false;
-    networkInterface.family.should.eql('IPv4');
-    networkInterface.address.split('.').length.should.eql(4);
+    expect(networkInterface.internal).to.be(false);
+    expect(networkInterface.family).to.be('IPv4');
+    expect(networkInterface.address.split('.').length).to.be(4);
   });
 });

--- a/test/unit/coverage.spec.js
+++ b/test/unit/coverage.spec.js
@@ -3,7 +3,7 @@
 /**
  * @author LinkedIn
  */
-var should        = require('../lib/sinon-chai').chai.should(),
+var expect        = require('expect.js'),
     coverage      = require('../../lib/coverage'),
     helpers       = require('../lib/helpers');
 
@@ -14,6 +14,6 @@ describe('lib/coverage/index', function () {
     data = helpers.codeCoverageData('1');
     results = coverage.parse(data);
 
-    Object.keys(results).length.should.eql(7);
+    expect(Object.keys(results).length).to.be(7);
   });
 });

--- a/test/unit/executor.socketio.spec.js
+++ b/test/unit/executor.socketio.spec.js
@@ -1,8 +1,7 @@
 /**
  * @author LinkedIn
  */
-var should     = require('../lib/sinon-chai').chai.should(),
-    sinon      = require('sinon'),
+var expect     = require('expect.js'),
     executor   = require('../../lib/executor'),
     ioclient   = require('socket.io-client'),
     express    = require('express');
@@ -22,7 +21,7 @@ describe('lib/executor -- socket.io', function() {
 
   it('should start a socket.io server on the right port', function(done) {
     socket.emit('ping', function(data) {
-      should.exist(data.port);
+      expect(data.port).not.to.be(undefined);
       done();
     });
   });
@@ -31,7 +30,7 @@ describe('lib/executor -- socket.io', function() {
     it('should handle invalid data', function(done) {
       // invalid result data
       socket.emit('results', {}, function(response) {
-        response.status.should.eql('error');
+        expect(response.status).to.be('error');
         done();
       });
     });
@@ -39,7 +38,7 @@ describe('lib/executor -- socket.io', function() {
     it('should handle valid data', function(done) {
       // valid result data
       socket.emit('results', { tests: [], done: { failed: 0, passed: 0, runtime: 0 }, userAgent: 'foo browser' }, function(response) {
-        response.status.should.eql('ok');
+        expect(response.status).to.be('ok');
         done();
       });
     });
@@ -49,7 +48,7 @@ describe('lib/executor -- socket.io', function() {
     it('should handle invalid data', function(done) {
       // invalid result data
       socket.emit('console.log', null, function(response) {
-        response.status.should.eql('error');
+        expect(response.status).to.be('error');
         done();
       });
     });
@@ -57,7 +56,7 @@ describe('lib/executor -- socket.io', function() {
     it('should handle valid data', function(done) {
       // valid result data
       socket.emit('console.log', 'test', function(response) {
-        response.status.should.eql('ok');
+        expect(response.status).to.be('ok');
         done();
       });
     });

--- a/test/unit/executor.spec.js
+++ b/test/unit/executor.spec.js
@@ -1,7 +1,7 @@
 /**
  * @author LinkedIn
  */
-var should      = require('../lib/sinon-chai').chai.should(),
+var expect      = require('expect.js'),
     sinon       = require('sinon'),
     executor    = require('../../lib/executor'),
     testHelper  = require('../lib/helpers'),
@@ -22,7 +22,7 @@ describe('lib/executor', function() {
 
   it('should not be modifiable', function() {
     executor.foo = 'bar';
-    should.not.exist(executor.foo);
+    expect(executor.foo).to.be(undefined);
   });
 
   it('should parse testcases from test string correctly', function() {
@@ -31,8 +31,8 @@ describe('lib/executor', function() {
         result;
 
     result = exec.parseTests(tests);
-    should.exist(result);
-    Object.keys(result).length.should.eql(3);
+    expect(result).to.be.ok();
+    expect(Object.keys(result).length).to.be(3);
   });
 
   it('should handle parsing testcases from undefined test string', function() {
@@ -41,8 +41,8 @@ describe('lib/executor', function() {
         result;
 
     result = exec.parseTests(tests);
-    should.exist(result);
-    Object.keys(result).length.should.eql(0);
+    expect(result).to.be.ok();
+    expect(Object.keys(result).length).to.be(0);
   });
 
   it('should handle tests being specified with a .js file extension', function() {
@@ -50,7 +50,7 @@ describe('lib/executor', function() {
         tests  = testPath( 'foo.js' ),
         result = exec.parseTests(tests);
 
-    Object.keys(result).length.should.eql(1);
+    expect(Object.keys(result).length).to.be(1);
   });
 
   it('should enforce require annotations option if specified', function () {
@@ -60,7 +60,7 @@ describe('lib/executor', function() {
 
     exec.requireTestAnnotations = true;
     result = exec.parseTests(tests);
-    Object.keys(result).length.should.eql(1);
+    expect(Object.keys(result).length).to.be(1);
   });
 
   it('should not enforce require annotations option if not specified', function () {
@@ -69,7 +69,7 @@ describe('lib/executor', function() {
         result;
 
     result = exec.parseTests(tests);
-    Object.keys(result).length.should.eql(2);
+    expect(Object.keys(result).length).to.be(2);
   });
 
   it('should parse comments in test cases', function() {
@@ -80,11 +80,11 @@ describe('lib/executor', function() {
 
     first = Object.keys(result)[0];
 
-    should.exist(result);
-    should.exist(result[first]);
-    result[first].annotations['venus-library'].should.eql('mocha');
-    result[first].annotations['venus-include'].should.have.length(2);
-    result[first].annotations['venus-include-group'].should.have.length(1);
+    expect(result).to.be.ok();
+    expect(result[first]).to.be.ok();
+    expect(result[first].annotations['venus-library']).to.be('mocha');
+    expect(result[first].annotations['venus-include'].length).to.be(2);
+    expect(result[first].annotations['venus-include-group'].length).to.be(1);
   });
 
   it('parseTestPaths should omit .venus folder', function() {
@@ -94,7 +94,7 @@ describe('lib/executor', function() {
 
     result = exec.parseTestPaths(testPaths);
 
-    Object.keys(result).length.should.eql(0);
+    expect(Object.keys(result).length).to.be(0);
   });
 
   describe('specify hostname on command line', function () {
@@ -113,7 +113,7 @@ describe('lib/executor', function() {
     url = exec.testgroup.testArray[0].url.run;
 
     it('should use the hostname specified on command line', function () {
-      url.indexOf('http://foobar.com').should.eql(0);
+      expect(url.indexOf('http://foobar.com')).to.be(0);
     });
   });
 
@@ -131,7 +131,7 @@ describe('lib/executor', function() {
     url = exec.testgroup.testArray[0].url.run;
 
     it('should use the hostname specified in config', function () {
-      url.indexOf('http://barfoo.com').should.eql(0);
+      expect(url.indexOf('http://barfoo.com')).to.be(0);
     });
   });
 
@@ -159,7 +159,7 @@ describe('lib/executor', function() {
       exec.createTestObjects([test]);
 
       // config.cwd is the dir of the file being tested
-      config.cwd.should.eql(path.dirname(test));
+      expect(config.cwd).to.be(path.dirname(test));
 
       // Verify expectations
       mock.verify();

--- a/test/unit/testrun.spec.js
+++ b/test/unit/testrun.spec.js
@@ -1,7 +1,7 @@
 /**
  * @author LinkedIn
  */
-var should     = require('../lib/sinon-chai').chai.should(),
+var expect     = require('expect.js'),
     testrun   = require('../../lib/testrun');
 
 describe('lib/testrun', function() {
@@ -10,23 +10,23 @@ describe('lib/testrun', function() {
     var run;
 
     run = testrun.create({ a: 1, b: 2 });
-    run.testCount.should.eql(2);
+    expect(run.testCount).to.be(2);
 
     run = testrun.create({});
-    run.testCount.should.eql(0);
+    expect(run.testCount).to.be(0);
 
     run = testrun.create({ a: 1 });
-    run.testCount.should.eql(1);
+    expect(run.testCount).to.be(1);
 
     run = testrun.create();
-    run.testCount.should.eql(0);
+    expect(run.testCount).to.be(0);
   });
 
   it('should return tests as an array', function() {
     var run;
 
     run = testrun.create({ a: 1, b: 2 });
-    run.testArray.should.eql([1, 2]);
+    expect(run.testArray).to.eql([1, 2]);
   });
 
   it('should return array of test urls', function() {
@@ -38,7 +38,7 @@ describe('lib/testrun', function() {
       c: { url: { run: 'http://localhost/3' } }
     });
 
-    run.urls.should.eql([
+    expect(run.urls).to.eql([
       { run: 'http://localhost/1' },
       { run: 'http://localhost/2' },
       { run: 'http://localhost/3' }]);

--- a/test/unit/util/commentsParser.spec.js
+++ b/test/unit/util/commentsParser.spec.js
@@ -1,12 +1,11 @@
 /**
  * @author LinkedIn
  */
-var should        = require('../../lib/sinon-chai').chai.should(),
+var expect     = require('expect.js'),
     parser     = require('../../../lib/util/commentsParser'),
     testHelper = require('../../lib/helpers'),
     fs         = require('fs'),
-    annotation = require('../../../lib/testcase').annotation,
-    expect     = require('expect.js');
+    annotation = require('../../../lib/testcase').annotation;
 
 describe('lib/util/commentsParser', function() {
 
@@ -88,58 +87,53 @@ describe('lib/util/commentsParser', function() {
 
     it('should handle an empty file', function() {
       var annotations = parser.parseStr(commentsD);
-      should.exist(annotations);
+      expect(annotations).to.be.ok();
     });
 
     it('should handle an annotation with no value', function() {
       var annotations = parser.parseStr(commentsE);
-      should.exist(annotations);
-      annotations.hasOwnProperty('param').should.be.true;
+      expect(annotations).to.be.ok();
+      expect(annotations.hasOwnProperty('param')).to.be(true);
     });
 
     it('should handle a file with no comments', function() {
       var annotations = parser.parseStr(commentsC);
-      should.exist(annotations);
+      expect(annotations).to.be.ok();
     });
 
     it('should parse 1 annotations object from 1 comment group', function() {
       var annotations   = parser.parseStr(commentsA);
-      should.exist(annotations);
+      expect(annotations).to.be.ok();
     });
 
     it('should parse 1 annotations object from 2 comment groups', function() {
       var annotations = parser.parseStr(commentsB);
-      should.exist(annotations);
+      expect(annotations).to.be.ok();
     });
 
     it('should parse unique annotations options correctly', function() {
       var annotations = parser.parseStr(commentsA);
 
-      should.exist(annotations['venus-framework']);
-      annotations['venus-framework'].should.equal('mocha');
+      expect(annotations['venus-framework']).to.be('mocha');
     });
 
     it('should parse duplicated annotations options correctly, spanning multiple blocks', function() {
       var annotations = parser.parseStr(commentsB);
 
-      should.exist(annotations[annotation.VENUS_INCLUDE]);
-      annotations[annotation.VENUS_INCLUDE].should.eql(['/var/www/html', '/var/www/bar']);
+      expect(annotations[annotation.VENUS_INCLUDE]).to.eql(['/var/www/html', '/var/www/bar']);
     });
 
     it('should parse include groups correctly', function() {
       var annotations = parser.parseStr(commentsB);
 
-      should.exist(annotations[annotation.VENUS_INCLUDE_GROUP]);
-      annotations[annotation.VENUS_INCLUDE_GROUP].should.eql(['my_group', 'another_group']);
+      expect(annotations[annotation.VENUS_INCLUDE_GROUP]).to.eql(['my_group', 'another_group']);
     });
 
     it('should parse file paths correctly', function() {
       var comments = buildCommentBlock('@venus-include ~/var/foo_test.js'),
           annotations = parser.parseStr(comments);
 
-      should.exist(annotations);
-      should.exist(annotations[annotation.VENUS_INCLUDE]);
-      annotations[annotation.VENUS_INCLUDE].should.eql('~/var/foo_test.js');
+      expect(annotations[annotation.VENUS_INCLUDE]).to.be('~/var/foo_test.js');
 
     });
 
@@ -147,17 +141,13 @@ describe('lib/util/commentsParser', function() {
       var comments = buildCommentBlock('@venus-include ~/var/test-file.js'),
           annotations = parser.parseStr(comments);
 
-      should.exist(annotations);
-      should.exist(annotations[annotation.VENUS_INCLUDE]);
-      annotations[annotation.VENUS_INCLUDE].should.eql('~/var/test-file.js');
+      expect(annotations[annotation.VENUS_INCLUDE]).to.be('~/var/test-file.js');
 
     });
 
     it('should parse annotation values with spaces correctly', function() {
       var annotations = parser.parseStr(commentsF);
-      should.exist(annotations);
-      should.exist(annotations[annotation.VENUS_FIXTURE]);
-      annotations[annotation.VENUS_FIXTURE].should.equal('<div class="sandbox"></div>');
+      expect(annotations[annotation.VENUS_FIXTURE]).to.be('<div class="sandbox"></div>');
     });
 
     it('should handle code with jshint style comment blocks', function () {

--- a/test/unit/util/pathHelper.spec.js
+++ b/test/unit/util/pathHelper.spec.js
@@ -1,7 +1,7 @@
 /**
  * @author LinkedIn
  */
-var should        = require('../../lib/sinon-chai').chai.should(),
+var expect        = require('expect.js'),
     pathHelper    = require('../../../lib/util/pathHelper');
 
 describe('lib/util/pathHelper', function() {
@@ -10,7 +10,7 @@ describe('lib/util/pathHelper', function() {
     var path = pathHelper('/test/var/foo');
 
     it('should have the correct path property', function() {
-      path.path.should.eql('/test/var/foo');
+      expect(path.path).to.be('/test/var/foo');
     });
   });
 
@@ -18,12 +18,12 @@ describe('lib/util/pathHelper', function() {
 
     it('should return filename', function() {
       var path = pathHelper('/test/var/foo');
-      path.file.should.eql('foo');
+      expect(path.file).to.be('foo');
     });
 
     it('should return directory name', function() {
       var path = pathHelper('/test/var/foo/');
-      path.file.should.eql('foo/');
+      expect(path.file).to.be('foo/');
     });
 
   });


### PR DESCRIPTION
Switching to expect.js for testing the Venus codebase. For consistency since the default assertion library for use with writing Venus.js client tests is expect.js.
