### PR TITLE
New annotation for code coverage `@venus-code`

### DIFF
--- a/examples/jasmine/Greeter/specs/Greeter.spec.js
+++ b/examples/jasmine/Greeter/specs/Greeter.spec.js
@@ -1,6 +1,6 @@
 /**
  * @venus-library jasmine
- * @venus-include ../src/Greeter.js
+ * @venus-code ../src/Greeter.js
  */
 
 describe('Greeter', function() {

--- a/examples/mocha/Greeter/specs/Greeter.spec.js
+++ b/examples/mocha/Greeter/specs/Greeter.spec.js
@@ -1,6 +1,6 @@
 /**
  * @venus-library mocha
- * @venus-include ../src/Greeter.js
+ * @venus-code ../src/Greeter.js
  */
 
 describe('Greeter', function() {

--- a/examples/mocha/ajax/specs/NusUpdate.spec.js
+++ b/examples/mocha/ajax/specs/NusUpdate.spec.js
@@ -4,7 +4,7 @@
  *
  * @venus-library mocha
  * @venus-include ../src/jquery.js
- * @venus-include ../src/NusUpdate.js
+ * @venus-code ../src/NusUpdate.js
  * @venus-fixture NusUpdate.fixture.html
  */
 

--- a/examples/mocha/injectjs/test/Greeter.spec.js
+++ b/examples/mocha/injectjs/test/Greeter.spec.js
@@ -1,6 +1,6 @@
 /**
  * @venus-library mocha
- * @venus-include ../Greeter.js
+ * @venus-code ../Greeter.js
  */
 
 describe('Greeter', function() {

--- a/examples/mocha/requirejs/test/Greeter.spec.js
+++ b/examples/mocha/requirejs/test/Greeter.spec.js
@@ -1,6 +1,6 @@
 /**
  * @venus-library mocha
- * @venus-include ../Greeter.js
+ * @venus-code ../Greeter.js
  */
 
 describe('Greeter', function() {

--- a/examples/qunit/Greeter/specs/Greeter.spec.js
+++ b/examples/qunit/Greeter/specs/Greeter.spec.js
@@ -1,6 +1,6 @@
 /**
  * @venus-library qunit
- * @venus-include ../src/Greeter.js
+ * @venus-code ../src/Greeter.js
  */
 
 test('Greeter', function() {

--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -34,6 +34,7 @@ var fs           = require('fs'),
       VENUS_FIXTURE: 'venus-fixture',
       VENUS_FIXTURE_RESET: 'venus-fixture-reset',
       VENUS_INCLUDE: 'venus-include',
+      VENUS_CODE: 'venus-code',
       VENUS_POST: 'venus-post',
       VENUS_PRE: 'venus-pre',
       VENUS_INCLUDE_GROUP: 'venus-include-group',
@@ -203,8 +204,10 @@ TestCase.prototype.prepareIncludes = function (annotations) {
       includes = [],
       fileMappings = [],
       includeFiles = annotations[annotation.VENUS_INCLUDE],
+      sourceCodeFiles = annotations[annotation.VENUS_CODE] || [],
       includeGroups = annotations[annotation.VENUS_INCLUDE_GROUP];
 
+  includeFiles = includeFiles.concat(sourceCodeFiles);
   httpRoot = this.getHttpRoot(testId);
   httpResourceUrls = [];
 
@@ -244,7 +247,8 @@ TestCase.prototype.prepareIncludes = function (annotations) {
   includeFiles.forEach(function (filePath) {
     var prepend  = '',
         parts,
-        basePath;
+        basePath,
+        rawFilePath = filePath;
 
     parts = filePath.split('/');
     basePath = config.get('basePaths', parts[0]);
@@ -273,7 +277,11 @@ TestCase.prototype.prepareIncludes = function (annotations) {
       filePath = pathm.resolve(this.directory + '/' + filePath);
     }
 
-    includes.push({ prepend: prepend, path: filePath, httpDir: 'includes', instrumentable: true });
+    if (sourceCodeFiles.indexOf(rawFilePath) !== -1) {
+      includes.push({ prepend: prepend, path: filePath, httpDir: 'includes', instrumentable: true });
+    } else {
+      includes.push({ prepend: prepend, path: filePath, httpDir: 'includes', instrumentable: false });
+    }
   }, this);
 
   // Add the testcase file


### PR DESCRIPTION
- `@venus-code` should be used to include the source code file that is under test.
- Files included with `@venus-code` will be instrumented for code coverage when `--coverage` flag is set
- Files included with `@venus-include` will never be instrumented for coverage
