### PR TITLE
Fix to prevent mocha tests from running twice

### DIFF
--- a/.venus/libraries/mocha-1.12.0.js
+++ b/.venus/libraries/mocha-1.12.0.js
@@ -1602,7 +1602,12 @@ Mocha.prototype.run = function(fn){
   if (options.grep) runner.grep(options.grep, options.invert);
   if (options.globals) runner.globals(options.globals);
   if (options.growl) this._growl(runner, reporter);
-  return runner.run(fn);
+
+  // Don't start runner automatically.
+  // We want to have a chance to attach listeners for events
+  // otherwise, this breaks in IE7/8
+  //return runner.run(fn);
+  return runner;
 };
 
 }); // module: mocha.js

--- a/test/regression/mocha/run-tests-once.js
+++ b/test/regression/mocha/run-tests-once.js
@@ -1,0 +1,16 @@
+/**
+ * @venus-library mocha
+ */
+describe('sample test', function () {
+  var spy = sinon.spy();
+
+  it('should only run once', function () {
+    spy();
+    expect(spy.callCount).to.be(1);
+  });
+
+  it('should only run twice', function () {
+    spy();
+    expect(spy.callCount).to.be(2);
+  });
+});


### PR DESCRIPTION
Due to how mocha gets instantiated, mocha tests were being run twice. Implemented a small hack to prevent this. Will look in to sending PR to mocha project to address this scenario.
