### PR TITLE
Fixed broken `venus demo` command

### DIFF
--- a/Venus.js
+++ b/Venus.js
@@ -175,7 +175,7 @@ Venus.prototype.run = function (program) {
  * @method Venus#runDemo
  */
 Venus.prototype.runDemo = function (program) {
-  var testFile = path.resolve(__dirname, 'examples', '06-SimpleCoverageTest', 'specs', 'Greeter.spec.js');
+  var testFile = path.resolve(__dirname, 'examples', 'mocha', 'Greeter');
 
   logger.verbose(i18n('Running demo'));
 


### PR DESCRIPTION
`venus demo` was broken recently when sample test folder structure was changed.
