### PR TITLE
Printing process stdout for Phantomjs in debug mode

### DIFF
--- a/lib/uac/GhostDriverUac.js
+++ b/lib/uac/GhostDriverUac.js
@@ -49,10 +49,18 @@ function GhostDriverUac(options) {
  */
 GhostDriverUac.prototype.start = function () {
   var def = deferred(),
-      binary = this.binaryPath || 'phantomjs';
+      binary = this.binaryPath || 'phantomjs',
+      stdout = '',
+      stderr = '';
 
   this.process = spawn(binary, ['--webdriver=' + this.options.port]);
   this.process.on('exit', function (code) {
+    log.debug('phantomjs stdout: ' + stdout);
+
+    if (stderr.length > 1) {
+      log.error('phantomjs stderr: ' + stderr);
+    }
+
     if (code === 127) {
       def.reject({message:'PhantomJS not found'});
     }
@@ -60,6 +68,13 @@ GhostDriverUac.prototype.start = function () {
 
   this.process.on('error', def.reject);
 
+  this.process.stdout.on('data', function (data) {
+    stdout += data;
+  });
+
+  this.process.stderr.on('data', function (data) {
+    stderr += data;
+  });
 
   setTimeout(function () {
     this.driver = new webdriver.Builder()
@@ -68,7 +83,7 @@ GhostDriverUac.prototype.start = function () {
 
     this.driver.manage().timeouts().implicitlyWait(5000);
     def.resolve(this);
-  }.bind(this), 500);
+  }.bind(this), 1000);
 
   return def.promise;
 };


### PR DESCRIPTION
When GhostDriverUac launches phantomjs, it will now print out the phantomjs stdout stream
when venus is run in debug mode.

stderr is logged as an error in all modes.
