### PR TITLE
Hotfix to give phantomjs a bit more time to start with GhostDriverUac.

### DIFF
--- a/lib/uac/GhostDriverUac.js
+++ b/lib/uac/GhostDriverUac.js
@@ -123,7 +123,7 @@ GhostDriverUac.prototype.start = function () {
 
       this.driver.manage().timeouts().implicitlyWait(5000);
       def.resolve(this);
-    }.bind(this), 1000);
+    }.bind(this), 2000);
   }
 
   return def.promise;


### PR DESCRIPTION
This introduces a bit of delay for all users of the GhostDriverUac. In future,
we will probably want a more intelligent mechanism to wait for phantomjs process to fully
initialize before proceeding.
