### PR TITLE
Adding code coverage summary output file

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -18,6 +18,9 @@
 // Parse code coverage data
 'use strict';
 
+var fs   = require('fs'),
+    path = require('path');
+
 function CodeCoverage() {}
 
 /**
@@ -53,7 +56,8 @@ CodeCoverage.prototype.parseFileData = function (filePath, data) {
  */
 CodeCoverage.prototype.parseTokenCoverage = function (data) {
   var total = 0,
-      covered = 0;
+      covered = 0,
+      tokens = {};
 
   Object.keys(data).forEach(function (token) {
     countTokenData(data[token]);
@@ -99,6 +103,62 @@ CodeCoverage.prototype.parseFunctions = function (data) {
  */
 CodeCoverage.prototype.parseBranches = function (data) {
   return this.parseTokenCoverage(data.b);
+};
+
+/**
+ * Write code coverage summary file
+ */
+CodeCoverage.prototype.writeSummary = function (data, outputPath) {
+  var fileOutput =
+    ['source file, total lines, code coverage, lines covered, lines not covered'];
+
+  outputPath = outputPath || 'coverage.csv';
+
+  data.forEach(function (obj) {
+    var fileData = obj[Object.keys(obj)[0]],
+        path = fileData.path,
+        statements = fileData.statementMap,
+        coveredLines = [],
+        line,
+        fileContents,
+        totalLinesInFile,
+        coveragePercentage,
+        uncoveredLines = [];
+
+    Object.keys(statements).forEach(function (key) {
+      var statement = statements[key],
+          startLine = statement.start.line,
+          endLine   = statement.end.line;
+
+      for (line = startLine; line <= endLine; line++) {
+        if (coveredLines.indexOf(line) === -1) {
+          coveredLines.push(line);
+        }
+      }
+
+    });
+
+    fileContents = fs.readFileSync(path).toString();
+    totalLinesInFile = fileContents.split('\n').length - 1;
+
+    for (line = 1; line <= totalLinesInFile; line++) {
+      if (coveredLines.indexOf(line) === -1) {
+        uncoveredLines.push(line);
+      }
+    }
+
+    coveragePercentage = (coveredLines.length / totalLinesInFile).toPrecision(2);
+
+    fileOutput.push([
+      path,
+      totalLinesInFile,
+      coveragePercentage,
+      coveredLines.join(' '),
+      uncoveredLines.join(' ')
+    ].join(','));
+  });
+
+  fs.writeFileSync(outputPath, fileOutput.join('\n'));
 };
 
 module.exports = new CodeCoverage();

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -715,6 +715,9 @@ Executor.prototype.shutdown = function () {
     this.reporter.emit('end', this.testgroup, this.endTime - this.startTime);
   }
 
+  // print code coverage summary file
+  coverage.writeSummary(this.testgroup.rawCodeCoverageData);
+
   if (this.hasFailures) {
     process.exit(1);
   } else {
@@ -730,6 +733,9 @@ Executor.prototype.onResults = function(data, done) {
   if(data) {
     results = this.printResults(data);
     this.printCodeCoverage(data.codeCoverageData);
+    if(!this.testgroup.addCodeCoverageResults(data.testId, data.codeCoverageData)) {
+      logger.debug('Unable to record code coverage results for test ' + data.testId);
+    }
   }
 
   if(!results) {

--- a/lib/testrun.js
+++ b/lib/testrun.js
@@ -15,34 +15,46 @@
  *     governing permissions and limitations under the License.
  **/
 
-// Keeps track of a test run for Venus application    
+// Keeps track of a test run for Venus application
 
 'use strict';
 var fs       = require('fs'),
     comments = require('./util/commentsParser');
 
-// Constructor for TestRun  
+// Constructor for TestRun
 function TestRun() {};
 
-// Initialize  
+// Initialize
 TestRun.prototype.init = function(tests) {
   this.tests = tests || {};
   this.defineProperties();
 };
 
-// Define properties  
+// Add code coverage results
+TestRun.prototype.addCodeCoverageResults = function (testId, data) {
+  var test = this.tests[testId];
+
+  if (test && data) {
+    test.rawCoverageData = data;
+    return true;
+  }
+
+  return false;
+};
+
+// Define properties
 TestRun.prototype.defineProperties = function() {
 
   Object.defineProperties(this, {
 
-    // Get the number of tests in this run group  
+    // Get the number of tests in this run group
     'testCount': {
       get: function() {
         return Object.keys(this.tests).length;
       }
     },
 
-    // Get the tests as an array  
+    // Get the tests as an array
     'testArray': {
       get: function() {
         return Object.keys(this.tests).map(function(key) {
@@ -51,11 +63,22 @@ TestRun.prototype.defineProperties = function() {
       }
     },
 
-    // Return test URLs  
+    // Return test URLs
     'urls': {
       get: function() {
         return this.testArray.map(function(test) {
           return test.url;
+        });
+      }
+    },
+
+    // Code coverage data array
+    'rawCodeCoverageData': {
+      get: function () {
+        return this.testArray.map(function (test) {
+          return test.rawCoverageData;
+        }).filter(function (data) {
+          return data !== undefined;
         });
       }
     }
@@ -64,7 +87,7 @@ TestRun.prototype.defineProperties = function() {
 
 };
 
-// Create a new TestRun object  
+// Create a new TestRun object
 function create(tests) {
   var instance = new TestRun();
   instance.init(tests);

--- a/test/unit/executor.socketio.spec.js
+++ b/test/unit/executor.socketio.spec.js
@@ -17,6 +17,11 @@ describe('lib/executor -- socket.io', function() {
       socket = ioclient.connect('http://localhost', { port: 2025 });
       done();
     });
+
+    exec.testgroup = {
+      addCodeCoverageResults: function () {}
+    };
+
   });
 
   it('should start a socket.io server on the right port', function(done) {


### PR DESCRIPTION
When run with `--coverage`, `coverage.csv` will be output in the current working directory.
Right now, this only works when running Venus in direct mode (with a specific environment, like phantomjs or supergrid).
