### PR TITLE
Improved performance of running with PhantomJS

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -730,11 +730,14 @@ Executor.prototype.onResults = function(data, done) {
 
   done = done || function() {};
 
-  if(data) {
+  if (data) {
     results = this.printResults(data);
-    this.printCodeCoverage(data.codeCoverageData);
-    if(!this.testgroup.addCodeCoverageResults(data.testId, data.codeCoverageData)) {
-      logger.debug('Unable to record code coverage results for test ' + data.testId);
+
+    if (data.codeCoverageData) {
+      this.printCodeCoverage(data.codeCoverageData);
+      if(!this.testgroup.addCodeCoverageResults(data.testId, data.codeCoverageData)) {
+        logger.debug('Unable to record code coverage results for test ' + data.testId);
+      }
     }
   }
 

--- a/lib/uac/GhostDriverUac.js
+++ b/lib/uac/GhostDriverUac.js
@@ -17,19 +17,22 @@
 
 var webdriver   = require('selenium-webdriver'),
     log         = require('../util/logger'),
-    i18n        = require('../util/i18n'),
     deferred    = require('deferred'),
     fsHelper    = require('../util/fsHelper'),
-    spawn       = require('child_process').spawn;
+    spawn       = require('child_process').spawn,
+    http        = require('http');
 
 /**
  * Controls a webdriver script
  */
 function GhostDriverUac(options) {
+  this.host = options.host || 'http://localhast';
+  this.port = options.port || 8910;
+
   this.server = [
-    options.host || 'http://localhost',
+    this.host || 'http://localhost',
     ':',
-    options.port
+    this.port
   ].join('');
 
   this.startAttempts = 0;
@@ -38,22 +41,12 @@ function GhostDriverUac(options) {
     this.server = 'http://' + this.server;
   }
 
-
   if (options && options.binaryPath) {
     this.binaryPath = fsHelper.getFirstValidPath(options.binaryPath);
   }
 
   this.options = options;
 }
-
-/**
- * Spawn PhantomJS process
- */
-GhostDriverUac.prototype.spawn = function (binary) {
-
-  this.process = spawn(binary, ['--webdriver=' + this.options.port]);
-
-},
 
 /**
  * Start the UAC
@@ -70,6 +63,8 @@ GhostDriverUac.prototype.start = function () {
     // Now, go ahead and start a new phantomjs process
     spawnPhantom.call(this);
   }.bind(this));
+
+  // spawnPhantom.call(this);
 
   function spawnPhantom () {
     this.process = spawn(binary, ['--webdriver=' + this.options.port]);
@@ -115,16 +110,63 @@ GhostDriverUac.prototype.start = function () {
       stderr += data;
     });
 
-    // Give PhantomJS a second to start and then try to kick off the webdriver client
-    setTimeout(function () {
-      this.driver = new webdriver.Builder()
-                                 .usingServer(this.server)
-                                 .build();
+    // Wait for PhantomJS to start...
+    this.waitForProcessStart().then(function () {
+        this.driver = new webdriver.Builder()
+                                   .usingServer(this.server)
+                                   .build();
 
-      this.driver.manage().timeouts().implicitlyWait(5000);
-      def.resolve(this);
-    }.bind(this), 5000);
+        this.driver.manage().timeouts().implicitlyWait(5000);
+        def.resolve(this);
+    }.bind(this), function (err) {
+      def.reject(err);
+    });
   }
+
+  return def.promise;
+};
+
+/**
+ * Poll until we get a valid response from GhostDriver server
+ */
+GhostDriverUac.prototype.waitForProcessStart = function () {
+  var def, options, request, maxAttempts, attempts;
+
+  maxAttempts = 300;
+  attempts = 0;
+
+  def = deferred(),
+  options = {
+    port: this.port,
+    host: this.host,
+    path: '/session',
+    method: 'POST'
+  };
+
+  function check() {
+    request = http.request(options, function (response) {
+      if (response.statusCode === 400) {
+        log.debug('PhantomJS webdriver is available! Proceed...');
+        def.resolve();
+      }
+    });
+
+    request.on('error', function (err) {
+      if (attempts < maxAttempts) {
+        attempts++;
+        setTimeout(function () {
+          check();
+        }, 50);
+      } else {
+        throw Error('Unable to connect to PhantomJS webdriver');
+      }
+    });
+
+    request.end();
+  }
+
+  log.debug('Sending HTTP request to see if PhantomJS webdriver server is available...');
+  check();
 
   return def.promise;
 };
@@ -142,11 +184,6 @@ GhostDriverUac.prototype.stop = function () {
   });
 
   this.process.kill('SIGTERM');
-  // setTimeout(function () {
-    // console.log('reject');
-    // def.reject();
-  // }, 1000);
-
 
   return def.promise;
 };

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "expect.js"              : "~0.2.0",
     "chokidar"               : "0.6.2",
     "flavored-path"          : "0.0.8",
-    "selenium-webdriver"     : "2.33.0",
+    "selenium-webdriver"     : "2.35.1",
     "deferred"               : "0.6.5",
     "phantomjs"              : "1.9.1-0"
   },


### PR DESCRIPTION
When running with GhostDriverUac (to execute tests with phantomjs), we were previously spawning the phantomjs process and then waiting several seconds before proceeding.
This was intended to give the phantomjs process enough time to spin up on slower machines.

With this change, rather than waiting an arbitrary length of time, we poll every 50ms to see if the process is up by sending an http request to the server which the process spawns.
After 300 attempts, we give up.
