### PR TITLE
Default to `run` command if not specified

### DIFF
--- a/Venus.js
+++ b/Venus.js
@@ -71,7 +71,19 @@ Venus.prototype.init = function (args) {
 
   // Define command line options
   program
-    .version(require('./package').version);
+    .version(require('./package').version)
+    .option('-p, --port [port]', i18n('port to run on'), function (value) { return parseInt(value, 10); })
+    .option('-l, --locale [locale]', i18n('Specify locale to use'))
+    .option('-v, --verbose', i18n('Run in verbose mode'))
+    .option('-d, --debug', i18n('Run in debug mode'))
+    .option('-c, --coverage', i18n('Generate Code Coverage Report'))
+    .option('--hostname [host]', i18n('Set hostname for test URLs, defaults to your ip address'))
+    .option('--no-annotations', i18n('Include test files with no Venus annotations (@venus-*)'))
+    .option('-e, --environment [env]', i18n('Specify environment to run tests in'))
+    .option('-r, --reporter [reporter]', i18n('Test reporter to use. Default is "DefaultReporter"'))
+    .option('-o, --output-file [path]', i18n('File to record test results'))
+    .option('-n, --phantom', i18n('Run with PhantomJS. This is a shortcut to --environment ghost'))
+    .option('--singleton', i18n('Ensures all other Venus processes are killed before starting'));
 
   // init command
   program
@@ -113,8 +125,41 @@ Venus.prototype.init = function (args) {
   program.parse(args);
 
   if (this.noCommand) {
-    program.outputHelp();
+    this.runWithDefaults();
   }
+};
+
+/**
+ * Try to auto run venus with default settings
+ */
+Venus.prototype.runWithDefaults = function () {
+  var args = this.commandLineArguments,
+      encounteredFlag = false,
+      possibleTestPaths;
+
+  if (args < 2) {
+    return false;
+  }
+
+  possibleTestPaths = args.slice(2).filter(function (testPath) {
+    if (testPath[0] === '-') {
+      encounteredFlag = true;
+    }
+
+    return !encounteredFlag;
+  });
+
+  logger.verbose(i18n('Running demo'));
+
+  if (possibleTestPaths.length === 0) {
+    possibleTestPaths = ['.'];
+  }
+
+  program.test =  possibleTestPaths.join(',');
+  // program.environment = 'ghost';
+  // program.coverage = true;
+  this.run(program);
+
 };
 
 /**

--- a/test/unit/Venus.spec.js
+++ b/test/unit/Venus.spec.js
@@ -29,4 +29,52 @@ describe('Venus main', function() {
     app.start(argv);
     expect(app.initProjectDirectory.calledOnce).to.be(true);
   });
+
+  describe('parse args in default mode', function () {
+    var argv, app;
+
+    beforeEach(function () {
+      app = new Venus();
+      argv = ['node', 'venus'];
+    });
+
+    it('should parse tests in default mode when comma delimited', function (done) {
+      argv.push('a.js,b.js,c.js');
+
+      app.run = function (program) {
+        expect(program.test).to.eql('a.js,b.js,c.js');
+        done();
+      };
+
+      app.start(argv);
+    });
+
+    it('should parse tests in default mode when space separated', function (done) {
+      argv.push('a.js');
+      argv.push('b.js');
+      argv.push('c.js');
+      argv.push('-e');
+      argv.push('ghost');
+
+      app.run = function (program) {
+        expect(program.test).to.eql('a.js,b.js,c.js');
+        expect(program.environment).to.eql('ghost');
+
+        done();
+      };
+
+      app.start(argv);
+    });
+
+    it('should operate on current directory when no tests are specified', function (done) {
+      argv.push('-e');
+
+      app.run = function (program) {
+        expect(program.test).to.eql('.');
+        done();
+      };
+
+      app.start(argv);
+    });
+  });
 });


### PR DESCRIPTION
You can now run venus without specifying the `run` command. This means that:

`venus run -t test1.js,test2.js -e ghost`

is now equivalent to:

`venus test1.js test2.js -e ghost`

and:

`venus test1.js,test2.js -e ghost`

Additionally, running `venus` with no arguments is now equivalent to running `venus run -t .`.
