### PR TITLE
Change default hostname value to 127.0.0.1

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -31,7 +31,7 @@ constants.getInterface = function () {
   var eth0 = os.networkInterfaces().eth0,
       retVal;
 
-  retVal = { address: '0.0.0.0', family: 'IPv4', internal: false };
+  retVal = { address: '127.0.0.1', family: 'IPv4', internal: false };
 
   if (eth0) {
     eth0 = eth0.filter(function (item) {


### PR DESCRIPTION
If IP address cannot be determined, we now default to 127.0.0.1 instead of 0.0.0.0. This fixes #245
