### PR TITLE
Auto-reload tests when source files change

### DIFF
--- a/js/runner_client/VenusClientLibrary.js
+++ b/js/runner_client/VenusClientLibrary.js
@@ -33,6 +33,14 @@ VenusClientLibrary.prototype.connect = function(){
     config.host,
     { port: config.port }
   );
+
+  this.socket.on('reload-test', function (testId) {
+    console.log('reload', testId);
+    if (testId === window.venus.testId) {
+      console.log('reloading me');
+      window.location.reload();
+    }
+  });
 };
 
 /**

--- a/js/runner_client/VenusTestList.js
+++ b/js/runner_client/VenusTestList.js
@@ -22,8 +22,10 @@
        resultClass = (passed) ? 'passed' : 'failed',
        pendingTestCount;
 
-   $el.addClass(resultClass);
    $el.removeClass('pending');
+   $el.removeClass('passed');
+   $el.removeClass('failed');
+   $el.addClass(resultClass);
 
    pendingTestCount = $('.test.pending').length;
 

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -346,10 +346,22 @@ Executor.prototype.createTestObjects = function (testPaths) {
       config: configHelper.getConfig(),
       hotReload: enableHotReload
     });
+
+    if (testObjects[testId]) {
+      testObjects[testId].on('reload', this.reloadTest.bind(this));
+    }
   }, this);
 
   return testObjects;
 
+};
+
+/**
+ * Reload test
+ * @param {object} test testcase object that has reloaded
+ */
+Executor.prototype.reloadTest = function (test) {
+  this.io.sockets.emit('reload-test', test.id);
 };
 
 // Get a new test id
@@ -751,13 +763,6 @@ Executor.prototype.onResults = function(data, done) {
     this.hasFailures = true;
   }
 
-  // if (this.env) {
-    // this.env.pendingTests--;
-    // if (this.env.pendingTests === 0) {
-      // // this.shutdown();
-    // }
-  // }
-
 };
 
 /**
@@ -782,7 +787,7 @@ Executor.prototype.start = function(port, onStart) {
     server = http.createServer(app);
     server.on('listening', function() {
       // Start socket.io server
-      io = ioserver.listen(hook, { 'log level': 0 });
+      this.io = io = ioserver.listen(hook, { 'log level': 0 });
       io.sockets.on('connection', function(socket) {
         socket.on('ping', function(fn) {
           fn({ time: Date.now(), port: port });
@@ -803,7 +808,7 @@ Executor.prototype.start = function(port, onStart) {
 
       def.resolve(port);
       onStart();
-    });
+    }.bind(this));
 
     server.on('error',_.bind(function(e) {
       if ( e && (e.code === 'EADDRINUSE')) {
@@ -812,7 +817,7 @@ Executor.prototype.start = function(port, onStart) {
     }, self));
 
     hook = server.listen(port);
-  });
+  }.bind(this));
 
   return def.promise;
 };

--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -29,6 +29,8 @@ var fs           = require('fs'),
     fstools      = require('fs-tools'),
     stringUtil   = require('./util/stringUtil'),
     mkdirp       = require('mkdirp'),
+    events       = require('events'),
+    util         = require('util'),
     Instrumenter = require('istanbul').Instrumenter,
     annotation   = {
       VENUS_FIXTURE: 'venus-fixture',
@@ -44,8 +46,9 @@ var fs           = require('fs'),
     };
 
 // Constructor for TestCase
-function TestCase() {
-}
+function TestCase() {}
+
+util.inherits(TestCase, events.EventEmitter);
 
 // Initialize
 TestCase.prototype.init = function(path, id, runUrl, runPath, instrumentCodeCoverage, hotReload) {
@@ -101,6 +104,7 @@ TestCase.prototype.watchFiles = function (files) {
   watcher.on('change', function (filePath) {
     logger.info('File ' + filePath + ' has changed, reloading test ' + this.id);
     this.load();
+    this.emit('reload', this);
   }.bind(this));
 
   files.forEach(function (file) {


### PR DESCRIPTION
Fix for #255. Whenever a source file or test file changes, browser will refresh to re-run test.
