### PR TITLE
Fix annotations parse error

### DIFF
--- a/lib/util/commentsParser.js
+++ b/lib/util/commentsParser.js
@@ -24,24 +24,25 @@ var _        = require('underscore'),
 
 // Parse string to hash
 function parseCommentsFromString(str) {
-  var blockRegex   = /\/\*([\s\S]*)\*\//,
+  var blockRegex   = /\/\*([\s\S]*?)\*\//g,
       hash         = {},
       blockMatches;
 
   blockMatches = str.match(blockRegex) || [];
 
   blockMatches.forEach(function (g) {
-    _(hash).extend(parseBlock(g));
+    // _(hash).extend(parseBlock(g));
+    hash = parseBlock(g, hash);
   });
 
   return hash;
 }
 
 // Parse a comment block
-function parseBlock (block) {
+function parseBlock (block, hash) {
   var paramRegex    = /@.*/g,
       paramMatches,
-      configBlock = {},
+      configBlock = hash || {},
       param;
 
   paramMatches = block.match(paramRegex);

--- a/test/unit/util/commentsParser.spec.js
+++ b/test/unit/util/commentsParser.spec.js
@@ -161,6 +161,29 @@ describe('lib/util/commentsParser', function() {
       annotations = parser.parseStr(commentsJshint);
       expect(annotations).not.to.be(undefined);
     });
+
+    it('should handle @ symbols in spec file', function () {
+      var commentsWithSymbol, annotations;
+
+      //  /**
+      //   * @venus-include ../www/test-file.js
+      //   */
+      //  var foo = 'ab@c.com';
+      //  var boo = 'c@ba.moc';
+      commentsWithSymbol = [
+          '/**\n',
+          ' * @venus-include ../www/test-file.js \n',
+          ' */\n',
+          'var foo = \'ab@c.com\';\n',
+          'var boo = \'c@ba.moc\';\n',
+          '/**\n',
+          ' */\n'
+        ].join('');
+
+      annotations = parser.parseStr(commentsWithSymbol);
+      expect(annotations[annotation.VENUS_INCLUDE]).to.be('../www/test-file.js');
+      expect(Object.keys(annotations).length).to.be(1);
+    });
   });
 
   /**


### PR DESCRIPTION
Fix for #286. Root cause was a greedy regex for parsing venus annotation blocks (multi-line comment blocks).
