### PR TITLE
Added support @venus-resource annotation

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -475,6 +475,29 @@ Executor.prototype.handleSandboxPage = function(request, response) {
 };
 
 /**
+* Responds to /sandbox/:testid/:resource route
+* @param {Object} request Request object
+* @param {Object} response Response object
+*/
+Executor.prototype.handleSandboxResource = function(request, response) {
+  var testId   = request.params.testid,
+      resource = request.params.resource,
+      path     = pathm.resolve(constants.userHome, '.venus_temp', 'test', testId, 'resources', resource);
+
+  // Send resource only if it exists
+  if (fs.existsSync(path)) {
+    response.sendfile(path);
+  }
+
+  // If resource does not exist, send 404
+  else {
+    return response.status(404).json(
+      { error: 'The resource ' + resource + ' does not exist' }
+    );
+  }
+};
+
+/**
 * Responds to /:testid route
 * @param {Object} request Request object
 * @param {Object} response Response object
@@ -608,6 +631,9 @@ Executor.prototype.initRoutes = function() {
 
   /** Serves the sandbox page **/
   app.get(this.urlNamespace + '/sandbox/:testid', this.handleSandboxPage.bind(this));
+
+  /** Serves sandbox resources **/
+  app.get(this.urlNamespace + '/sandbox/:testid/:resource', this.handleSandboxResource.bind(this));
 
   // Serves the page that will render the sandbox in an iframe
   app.get(this.urlNamespace + '/:testid', this.handleNamespacePage.bind(this));

--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -37,6 +37,7 @@ var fs           = require('fs'),
       VENUS_FIXTURE_RESET: 'venus-fixture-reset',
       VENUS_INCLUDE: 'venus-include',
       VENUS_CODE: 'venus-code',
+      VENUS_RESOURCE: 'venus-resource',
       VENUS_POST: 'venus-post',
       VENUS_PRE: 'venus-pre',
       VENUS_INCLUDE_GROUP: 'venus-include-group',
@@ -70,6 +71,7 @@ TestCase.prototype.load = function () {
 
   this.harnessTemplate        = this.loadHarnessTemplate(this.annotations);
   this.includes               = this.prepareIncludes(this.annotations);
+  this.resources              = this.prepareResources(this.annotations);
   this.url.includes           = this.copyFilesToHttpPath(this.includes).urls;
 
   if (this.watcher) {
@@ -312,6 +314,98 @@ TestCase.prototype.prepareIncludes = function (annotations) {
       instrumentable: instrumentable
     });
 
+  });
+
+  return fileMappings;
+};
+
+// Prepare testcase resources
+// There are external resources that are accessible within the sandbox
+// These are included via @venus-resource annotation
+TestCase.prototype.prepareResources = function (annotations) {
+  var testId        = this.id,
+      config        = this.config,
+      httpRoot      = this.getHttpRoot(testId),
+      resourceFiles = annotations[annotation.VENUS_RESOURCE] || [],
+      resources     = [],
+      fileMappings  = [];
+
+  // Make sure to put all resources in an array
+  if (!Array.isArray(resourceFiles)) {
+    resourceFiles = [resourceFiles];
+  }
+
+  // For each resource, determine the following:
+  // - prepend         [characters to prepend resource name]
+  // - path            [path to resource on file system]
+  // - httpDir         [name of directory to put resource in so it's accessible via http]
+  // - instrumentable  [whether or not to apply code coverage to resource]
+  resourceFiles.forEach(function (filePath) {
+    var prepend  = '',
+        parts,
+        basePath,
+        rawFilePath = filePath;
+
+    parts = filePath.split('/');
+    basePath = config.get('basePaths', parts[0]);
+
+    // Base path exists in config file
+    if (basePath) {
+      parts[0] = basePath;
+      filePath = parts.join('/');
+    }
+
+    // For each part of the path, determine prepend
+    parts.forEach(function (part, index) {
+      if (index === parts.length - 1) {
+        return;
+      }
+
+      if (part === '..') {
+        prepend += '_.';
+      } else if (part === '.') {
+        prepend += '';
+      } else if (part) {
+        prepend += part + '.';
+      }
+    });
+
+    // if path doesn't begin with a '/' character, we assume it
+    // is relative and needs to be resolved relative
+    // to the directory the testcase file lives in
+    if (filePath[0] !== '/') {
+      filePath = pathm.resolve(this.directory + '/' + filePath);
+    }
+
+    // Add to resources array
+    resources.push({ prepend: prepend, path: filePath, httpDir: 'resources', instrumentable: false});
+  }, this);
+
+  // Take list of resources and copy them to a temporary location
+  // on the server. The path is {venus install location}/temp/test/{testid}/resources
+  resources.forEach(function (resource) {
+    var filePath       = resource.path,
+        httpDir        = resource.httpDir,
+        destination    = pathm.resolve(httpRoot + '/' + httpDir + '/' + pathHelper(filePath).file),
+        httpUrl        = '/' + destination.substr(destination.indexOf('temp/test/' + testId)),
+        instrumentable = resource.instrumentable;
+
+    // Add to list of file mappings
+    //  fs   = original file path on disk
+    //  http = relative http path to file on server
+    fileMappings.push({
+      fs: filePath,
+      http: destination,
+      url: httpUrl,
+      instrumentable: instrumentable
+    });
+
+    // Add resource to http path
+    fstools.copy(filePath, destination, function(err) {
+      if (err) {
+        logger.debug(i18n('Error copying test file %s to %s. Exception: %s', filePath, destination, err));
+      }
+    });
   });
 
   return fileMappings;


### PR DESCRIPTION
The **@venus-resource** annotation can be used to make external files available within the sandbox. This makes it possible to do such things as fetching files via AJAX in your unit test. 

Here is an example: 

``` javascript
/**
 * @venus-library qunit
 * @venus-include jquery.js
 * @venus-resource data1.txt
 * @venus-resource foo/data2.txt
 * @venus-resource foo/bar/data3.txt
 * @venus-resource ../../data4.txt
 */
$.get(location.href + '/data1.txt')
.success(function() {
  ok(true, 'pass');
});
```

If the test is running on [http://localhost:2013/venus-core/1](http://localhost:2013/venus-core/1), the resources will be available at the following URLs:
- [http://localhost:2013/venus-core/sandbox/1/data1.txt](http://localhost:2013/venus-core/sandbox/1/data1.txt)
- [http://localhost:2013/venus-core/sandbox/1/data2.txt](http://localhost:2013/venus-core/sandbox/1/data2.txt)
- [http://localhost:2013/venus-core/sandbox/1/data3.txt](http://localhost:2013/venus-core/sandbox/1/data3.txt)
- [http://localhost:2013/venus-core/sandbox/1/data4.txt](http://localhost:2013/venus-core/sandbox/1/data4.txt)

I decided to put all resources in the same http directory (without any subdirectories) so they can be accessed in a lightweight fashion. 
