### PR TITLE
New @venus-execute annotation

### DIFF
--- a/.venus/templates/sandbox.tl
+++ b/.venus/templates/sandbox.tl
@@ -13,7 +13,9 @@
   </script>
   <script src="{testcaseFile}"></script>
   <script type="text/javascript">
-    window.adaptor.start();
+    window.parent.venus.beforeHook().then(function () {
+      window.adaptor.start();
+    });
   </script>
 </body>
 </html>

--- a/examples/mocha/Hooks/Tree.js
+++ b/examples/mocha/Hooks/Tree.js
@@ -1,0 +1,3 @@
+function Tree(id) {
+  this.id = id;
+}

--- a/examples/mocha/Hooks/Tree.spec.js
+++ b/examples/mocha/Hooks/Tree.spec.js
@@ -1,0 +1,20 @@
+/**
+ * @venus-library mocha
+ * @venus-code ./Tree.js
+ * @venus-execute ./setup.js
+ * @venus-execute ./setup_async.js
+ */
+
+describe('Tree', function() {
+  var tree;
+
+  before(function () {
+    tree = new Tree(23);
+  });
+
+
+  it('should have the correct id', function () {
+    expect(tree.id).to.be(23);
+  });
+
+});

--- a/examples/mocha/Hooks/setup.js
+++ b/examples/mocha/Hooks/setup.js
@@ -1,0 +1,3 @@
+module.exports.before = function (ctx) {
+  console.log('before hook:', ctx);
+};

--- a/examples/mocha/Hooks/setup_async.js
+++ b/examples/mocha/Hooks/setup_async.js
@@ -1,0 +1,20 @@
+module.exports.before = function (ctx) {
+  var when, def;
+
+  try {
+    when = require('when');
+  } catch (e) {
+    console.log('Run `npm install -g when` before running this example');
+    return;
+  }
+
+  def  = when.defer();
+
+  setTimeout(function () {
+    console.log('before hook: 5 seconds later...');
+    console.log('before hook ctx:', ctx);
+    def.resolve();
+  }, 5000);
+
+  return def.promise;
+};

--- a/js/runner_client/VenusClientLibrary.js
+++ b/js/runner_client/VenusClientLibrary.js
@@ -35,7 +35,6 @@ VenusClientLibrary.prototype.connect = function(){
   );
 
   this.socket.on('reload-test', function (testId) {
-    console.log('reload', testId);
     if (testId === window.venus.testId) {
       console.log('reloading me');
       window.location.reload();
@@ -73,4 +72,18 @@ VenusClientLibrary.prototype.done = function( results ){
 VenusClientLibrary.prototype.log = function () {
   var str = Array.prototype.slice.call(arguments, 0).join(' ');
   this.socket.emit( 'console.log', str);
+};
+
+/**
+ * Execute server side hook
+ * @param {String} hookName hook
+ */
+VenusClientLibrary.prototype.beforeHook = function (hookName) {
+  var def = $.Deferred();
+
+  this.socket.emit('execute:before:hook', { testId: window.venus.testId }, function () {
+    def.resolve();
+  });
+
+  return def.promise();
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -253,7 +253,7 @@ module.exports.makePathsAbsolute = function (data, configFileDirectory) {
 
   if (Array.isArray(data)) {
     return data.map(function (item) {
-      return this.makePathsAbsolute(item);
+      return this.makePathsAbsolute(item, configFileDirectory);
     }, this);
   } else if (typeof data === 'object') {
     Object.keys(data).forEach(function (key) {

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -372,7 +372,7 @@ Executor.prototype.getNextTestId = function() {
 // Set up application environment
 Executor.prototype.initEnvironment = function(config) {
   var app        = this.app = express(),
-  homeFolder = this.homeFolder = config.homeFolder;
+      homeFolder = this.homeFolder = config.homeFolder || __dirname;
 
   // express config
   app.engine('tl', consolidate.dust);
@@ -828,6 +828,20 @@ Executor.prototype.start = function(port, onStart) {
           } else {
             logger.info( 'console: ' + data.yellow );
             done({ status: 'ok' });
+          }
+        });
+
+        socket.on('execute:before:hook', function (data, done) {
+          var testId, result, test;
+
+          data = data || {};
+          testId = data.testId;
+          test = self.testgroup.getTestById(testId);
+
+          if (test) {
+            test.executeHook('before').then(done);
+          } else {
+            done();
           }
         });
       });

--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -19,6 +19,7 @@
 
 'use strict';
 var fs           = require('fs'),
+    when         = require('when'),
     comments     = require('./util/commentsParser'),
     pathHelper   = require('./util/pathHelper'),
     logger       = require('./util/logger'),
@@ -43,7 +44,8 @@ var fs           = require('fs'),
       VENUS_INCLUDE_GROUP: 'venus-include-group',
       VENUS_LIBRARY: 'venus-library',
       VENUS_TEMPLATE: 'venus-template',
-      VENUS_TYPE: 'venus-type'
+      VENUS_TYPE: 'venus-type',
+      VENUS_EXECUTE: 'venus-execute'
     };
 
 // Constructor for TestCase
@@ -71,6 +73,7 @@ TestCase.prototype.load = function () {
 
   this.harnessTemplate        = this.loadHarnessTemplate(this.annotations);
   this.includes               = this.prepareIncludes(this.annotations);
+  this.executeScripts         = this.prepareExecuteScripts(this.annotations);
   this.resources              = this.prepareResources(this.annotations);
   this.url.includes           = this.copyFilesToHttpPath(this.includes).urls;
 
@@ -122,11 +125,12 @@ TestCase.prototype.watchFiles = function (files) {
 // Resolve annotations
 // Use default values for missing annotations
 TestCase.prototype.resolveAnnotations = function(annotations) {
-  var conf  =  this.config,
-      library = annotations[annotation.VENUS_LIBRARY],
-      include = annotations[annotation.VENUS_INCLUDE],
-      groups = annotations[annotation.VENUS_INCLUDE_GROUP],
-      fixture = annotations[annotation.VENUS_FIXTURE],
+  var conf         = this.config,
+      library      = annotations[annotation.VENUS_LIBRARY],
+      include      = annotations[annotation.VENUS_INCLUDE],
+      groups       = annotations[annotation.VENUS_INCLUDE_GROUP],
+      fixture      = annotations[annotation.VENUS_FIXTURE],
+      execute      = annotations[annotation.VENUS_EXECUTE],
       fixturePath;
 
   if ( !library ) {
@@ -183,6 +187,17 @@ TestCase.prototype.resolveAnnotations = function(annotations) {
 
   annotations[annotation.VENUS_FIXTURE] = fixture;
 
+  // Execute scripts.
+  // These are executed server side before and after running tests in browser.
+  if (!execute) {
+    execute = [];
+  } else if (!Array.isArray(execute)) {
+    execute = [execute];
+  }
+
+  annotations[annotation.VENUS_EXECUTE] = execute;
+
+
   return annotations;
 };
 
@@ -225,7 +240,6 @@ TestCase.prototype.prepareIncludes = function (annotations) {
   if (config.includes && config.includes.default) {
     includes = includes.concat(config.includes.default);
   }
-
 
   // Add include group files
   includeGroups.forEach(function (groupName) {
@@ -317,6 +331,63 @@ TestCase.prototype.prepareIncludes = function (annotations) {
   });
 
   return fileMappings;
+};
+
+// Prepare 
+TestCase.prototype.prepareExecuteScripts = function (annotations) {
+  var scripts, modules;
+
+  scripts = annotations[annotation.VENUS_EXECUTE];
+  modules = [];
+
+  scripts.forEach(function (script) {
+    var scriptPath, module;
+
+    scriptPath = pathm.resolve(this.directory, script);
+
+    try {
+      module     = require(scriptPath);
+      modules.push(module);
+    } catch (e) {
+      // Debug: unable to load module
+    }
+
+  }, this);
+
+  return modules;
+};
+
+// Execute scripts hook
+TestCase.prototype.executeHook = function (hook) {
+  var ctx      = this.executeContext(),
+      promises = [];
+
+  this.executeScripts.forEach(function (script) {
+    var result;
+
+    if (typeof script[hook] === 'function') {
+      result = script[hook](ctx);
+
+      if (result && typeof result.then === 'function') {
+        promises.push(result);
+      }
+
+    }
+  }, this);
+
+  if (promises.length === 0) {
+    return when.defer().resolve();
+  } else {
+    return when.all(promises);
+  }
+};
+
+// Build execute context which is passed to execute scripts
+TestCase.prototype.executeContext = function () {
+  return {
+    testPath: this.path,
+    testId: this.id
+  };
 };
 
 // Prepare testcase resources

--- a/lib/testrun.js
+++ b/lib/testrun.js
@@ -32,7 +32,7 @@ TestRun.prototype.init = function(tests) {
 
 // Add code coverage results
 TestRun.prototype.addCodeCoverageResults = function (testId, data) {
-  var test = this.tests[testId];
+  var test = this.getTestById(testId);
 
   if (test && data) {
     test.rawCoverageData = data;
@@ -85,6 +85,20 @@ TestRun.prototype.defineProperties = function() {
 
   });
 
+};
+
+// Get test by id
+TestRun.prototype.getTestById = function (id) {
+  var match;
+
+  this.testArray.some(function (test) {
+    if (test.id === id) {
+      match = test;
+      return true;
+    }
+  });
+
+  return match;
 };
 
 // Create a new TestRun object

--- a/locales/pirate.js
+++ b/locales/pirate.js
@@ -156,5 +156,6 @@
 	"Disabling hot reload because there are more than 5 tests loaded": "Disabling hot reload because there are more than 5 tests loaded",
 	"Ensures all other Venus processes are killed before starting": "Ensures all other Venus processes are killed before starting",
 	"Using environment ie8": "Using environment ie8",
-	"Using environment ie7": "Using environment ie7"
+	"Using environment ie7": "Using environment ie7",
+	"Use https": "Use https"
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "flavored-path"          : "0.0.8",
     "selenium-webdriver"     : "2.35.1",
     "deferred"               : "0.6.5",
+    "when"                   : "2.5.1",
     "phantomjs"              : "1.9.1-0"
   },
   "devDependencies": {

--- a/test/data/sample_tests/execute.js
+++ b/test/data/sample_tests/execute.js
@@ -1,0 +1,6 @@
+/**
+ *  @venus-library mocha
+ *  @venus-execute execute/setup.js
+ */
+
+var javascript = true;

--- a/test/data/sample_tests/execute/setup.js
+++ b/test/data/sample_tests/execute/setup.js
@@ -1,0 +1,3 @@
+module.exports.before = function () {
+  return 'before hook';
+};

--- a/test/unit/executor.spec.js
+++ b/test/unit/executor.spec.js
@@ -106,7 +106,8 @@ describe('lib/executor', function() {
 
     options = {
       hostname: 'foobar.com',
-      test: test
+      test: test,
+      homeFolder: __dirname
     };
 
 

--- a/test/unit/testcase.spec.js
+++ b/test/unit/testcase.spec.js
@@ -173,4 +173,30 @@ describe('lib/testcase', function () {
       expect(httpRoot).to.be(path.resolve(home, '.venus_temp', 'test', '1'));
     });
   });
+
+  describe('Usage of @venus-execute annotation', function () {
+    describe('Load script to execute', function () {
+      it('should get correct path for execute script', function () {
+        var expectedPath = 'execute/setup.js', annotations;
+
+        test.path   = testHelper.sampleTests('execute.js');
+        testData    = test.parseTestFile(test.path).annotations;
+        annotations = test.resolveAnnotations(testData);
+
+        expect(annotations['venus-execute']).to.eql([expectedPath]);
+      });
+
+      it('should require module', function () {
+        var annotations, scripts;
+
+        test.path   = testHelper.sampleTests('execute.js');
+        testData    = test.parseTestFile(test.path).annotations;
+        annotations = test.resolveAnnotations(testData);
+        scripts     = test.prepareExecuteScripts(annotations);
+
+        expect(scripts.length).to.be(1);
+        expect(scripts[0].before()).to.be('before hook');
+      });
+    });
+  });
 });


### PR DESCRIPTION
Use `@venus-execute` to run code in node before a test runs in the
browser. For usage, please see the `examples/Hooks` folder.

Note: we plan to support additional hooks in the future, such as
`beforeEach`, and `after/afterEach`.
