### PR TITLE
Added documentation for @venus-fixture-reset annotation

### DIFF
--- a/docs/source/reference/annotations.rst
+++ b/docs/source/reference/annotations.rst
@@ -84,7 +84,7 @@ Example:
 @venus-fixture-reset
 --------------------
 
-Disable the behavior of resetting test HTML fixtures after each test executes (default value is true)
+Disable the behavior of resetting test HTML fixtures after each test executes (Default value is true)
 
 Example:
 


### PR DESCRIPTION
I also reordered the documentation for annotations as follows:
- @venus-library
- @venus-include
- @venus-include-group
- @venus-fixture
- @venus-fixture-reset
- @venus-template
- @venus-code
- @venus-resource
- @venus-execute
