### PR TITLE
Fix commentParser to parse JSDoc tags

### DIFF
--- a/lib/util/commentsParser.js
+++ b/lib/util/commentsParser.js
@@ -59,14 +59,19 @@ function parseBlock (block, hash) {
       currentValue  = configBlock[name];
 
       // If this is the first time we've seen this config property, add it.
-      // Otherwise, if the current value is a string, move it to an array
-      // if it's already in an array, then append to that array
       if(typeof currentValue === 'undefined') {
         configBlock[name] = value;
-      } else if(typeof currentValue === 'string') {
-        configBlock[name] = [currentValue, value];
-      } else if(typeof currentValue.length !== 'undefined') {
-        configBlock[name].push(value);
+        return;
+      }
+      // Otherwise if config property has a value
+      if(typeof value !== 'undefined') {
+        // And the current value is a string, move it to an array
+        // if it's already in an array, then append to that array
+        if(typeof currentValue === 'string') {
+          configBlock[name] = [currentValue, value];
+        } else if (typeof currentValue.length !== 'undefined') {
+          configBlock[name].push(value);
+        }
       }
     });
   }
@@ -76,7 +81,7 @@ function parseBlock (block, hash) {
 
 // Parse a parameter
 function parseParam(param) {
-  var kvRegex     = /([\w-]+)\s+(.+)?/,
+  var kvRegex     = /([\w-]+)(?:\s+(.+))?/,
       kvMatches   = param.match(kvRegex),
       parsedParam,
       name,

--- a/test/unit/util/commentsParser.spec.js
+++ b/test/unit/util/commentsParser.spec.js
@@ -184,6 +184,50 @@ describe('lib/util/commentsParser', function() {
       expect(annotations[annotation.VENUS_INCLUDE]).to.be('../www/test-file.js');
       expect(Object.keys(annotations).length).to.be(1);
     });
+
+    it('shouldn\'t fail on JSDoc comments', function() {
+      var commentsWithJSDoc, annotations;
+
+      //  /**
+      //   * @type String
+      //   */
+      //  var a = 'my string';
+      commentsWithJSDoc = [
+        '/**\n',
+        ' * @type String\n',
+        ' */\n',
+        'var a = \'my string\'',
+      ].join('');
+
+      annotations = parser.parseStr(commentsWithJSDoc);
+      expect(annotations).not.to.be(undefined);
+
+      //  /**
+      //   * @param {Array} p
+      //   * @private
+      //   */
+      //  function _myFirstPrivate(p) {}
+      //  /**
+      //   * @param {String} p
+      //   * @private
+      //   */
+      //  function _mySecPrivate(p) {}
+      commentsWithJSDoc = [
+          '/**\n',
+          ' * @param Array\n',
+          ' * @private\n',
+          ' */\n',
+          'function _myFirstPrivate(p) {}\n',
+          '/**\n',
+          ' * @param String\n',
+          ' * @private\n',
+          ' */\n',
+          'function _mySecPrivate(p) {}\n'
+      ].join('');
+
+      annotations = parser.parseStr(commentsWithJSDoc);
+      expect(annotations).not.to.be(undefined);
+    });
   });
 
   /**


### PR DESCRIPTION
For now _venus_ fails to parse test suites that contains more than one "boolean" JSDoc tags e.g. `@private`.
