### PR TITLE
Fix commentsParser regression after #319 had been lost

### DIFF
--- a/lib/util/commentsParser.js
+++ b/lib/util/commentsParser.js
@@ -64,16 +64,16 @@ function parseBlock (block, hash) {
           currentValue = configBlock[name];
 
       // If this is the first time we've seen this config property, add it.
-      if (typeof currentValue === 'undefined') {
+      if (currentValue == null) {
         configBlock[name] = value;
       }
       // Otherwise if config property has a value
-      else if (typeof value !== 'undefined') {
+      else if (value != null) {
         // And the current value is a string, move it to an array
         // if it's already in an array, then append to that array
         if (typeof currentValue === 'string') {
           configBlock[name] = [currentValue, value];
-        } else if (currentValue.length !== undefined) {
+        } else if (typeof currentValue.length !== 'undefined') {
           configBlock[name].push(value);
         }
       }
@@ -91,8 +91,8 @@ function parseBlock (block, hash) {
  * @returns {Object} parsedParams - the name and value of the parameter
  */
 function parseParam (param) {
-  var kvRegex     = /([\w-]+)(?:\s+(.+))?/,
-      kvMatches   = param.match(kvRegex),
+  var kvRegex      = /([\w-]+)(?:\s+(.+))?/,
+      kvMatches    = param.match(kvRegex),
       parsedParams = {
         name  : null,
         value : null

--- a/test/unit/util/commentsParser.spec.js
+++ b/test/unit/util/commentsParser.spec.js
@@ -184,6 +184,50 @@ describe('lib/util/commentsParser', function() {
       expect(annotations[annotation.VENUS_INCLUDE]).to.be('../www/test-file.js');
       expect(Object.keys(annotations).length).to.be(1);
     });
+
+    it('shouldn\'t fail on JSDoc comments', function() {
+      var commentsWithJSDoc, annotations;
+
+      //  /**
+      //   * @type String
+      //   */
+      //  var a = 'my string';
+      commentsWithJSDoc = [
+        '/**\n',
+        ' * @type String\n',
+        ' */\n',
+        'var a = \'my string\'',
+      ].join('');
+
+      annotations = parser.parseStr(commentsWithJSDoc);
+      expect(annotations).not.to.be(undefined);
+
+      //  /**
+      //   * @param {Array} p
+      //   * @private
+      //   */
+      //  function _myFirstPrivate(p) {}
+      //  /**
+      //   * @param {String} p
+      //   * @private
+      //   */
+      //  function _mySecPrivate(p) {}
+      commentsWithJSDoc = [
+          '/**\n',
+          ' * @param Array\n',
+          ' * @private\n',
+          ' */\n',
+          'function _myFirstPrivate(p) {}\n',
+          '/**\n',
+          ' * @param String\n',
+          ' * @private\n',
+          ' */\n',
+          'function _mySecPrivate(p) {}\n'
+      ].join('');
+
+      annotations = parser.parseStr(commentsWithJSDoc);
+      expect(annotations).not.to.be(undefined);
+    });
   });
 
   /**


### PR DESCRIPTION
For some reason part of code from #319 has been lost in master. This PR brings it back, while fixing "TypeError: Cannot read property 'length' of null" from #312

closes #321
