### PR TITLE
Fix VenusUi#onResults scope

### DIFF
--- a/js/runner_client/VenusUi.js
+++ b/js/runner_client/VenusUi.js
@@ -44,7 +44,9 @@ function VenusUi(config) {
     self.showSandbox();
   });
 
-  $(document).on('results', self.onResults);
+  $(document).on('results', function () {
+    self.onResults.apply(self, arguments);
+  });
 }
 
 /**


### PR DESCRIPTION
`$(document).on('results')`'s event handler is invoking in target's scope (`document` in this case).
