### PR TITLE
Generating coverage.csv file should be optional

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -108,7 +108,7 @@ CodeCoverage.prototype.parseBranches = function (data) {
 /**
  * Write code coverage summary file
  */
-CodeCoverage.prototype.writeSummary = function (data, outputPath) {
+CodeCoverage.prototype.writeSummary = function (data, isCodeCoverageEnabled, outputPath) {
   var fileOutput =
     ['source file, total lines, code coverage, lines covered, lines not covered'];
 
@@ -158,7 +158,10 @@ CodeCoverage.prototype.writeSummary = function (data, outputPath) {
     ].join(','));
   });
 
-  fs.writeFileSync(outputPath, fileOutput.join('\n'));
+  // If command line option for code coverage is enabled (-c, --coverage), write coverage file to the file system
+  if (isCodeCoverageEnabled) {
+    fs.writeFileSync(outputPath, fileOutput.join('\n'));
+  }
 };
 
 module.exports = new CodeCoverage();

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -73,9 +73,7 @@ Executor.prototype.init = function(options, onStart) {
   }
 
   // set code coverage flag
-  if (options.coverage) {
-    this.enableCodeCoverage = true;
-  }
+  this.enableCodeCoverage = options.coverage ? true : false;
 
   // set require annotations flag
   if (options.noAnnotations) {
@@ -754,7 +752,7 @@ Executor.prototype.shutdown = function () {
   }
 
   // print code coverage summary file
-  coverage.writeSummary(this.testgroup.rawCodeCoverageData);
+  coverage.writeSummary(this.testgroup.rawCodeCoverageData, this.enableCodeCoverage);
 
   if (this.hasFailures) {
     process.exit(1);


### PR DESCRIPTION
Only create coverage.csv file if command line option is used (-c, --coverage)
