### PR TITLE
Implement "transform" hook for pre-processing source files

### DIFF
--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -360,13 +360,14 @@ TestCase.prototype.prepareExecuteScripts = function (annotations) {
 // Execute scripts hook
 TestCase.prototype.executeHook = function (hook) {
   var ctx      = this.executeContext(),
-      promises = [];
+      promises = [],
+      hookArgs = Array.prototype.slice.call(arguments, 1);
 
   this.executeScripts.forEach(function (script) {
     var result;
 
     if (typeof script[hook] === 'function') {
-      result = script[hook](ctx);
+      result = script[hook].apply(this, [ctx].concat(hookArgs));
 
       if (result && typeof result.then === 'function') {
         promises.push(result);
@@ -488,38 +489,47 @@ TestCase.prototype.copyFilesToHttpPath = function (files) {
       // var symMkdirPath = path.http.replace(/\/(?:.(?!\/))+$/, '');
       urls.push(path.url);
 
-      // only instrument file for code coverage if option is enabled and file is an @venus-include
-      if (this.instrumentCodeCoverage && path.instrumentable) {
-        // instrument the file with istanbul
-        instrumenter = new Instrumenter();
+      // Copy everything to http location; treat as "build" path
+      fstools.copy(path.fs, path.http, function(err) {
+        if (err) {
+          logger.debug(i18n('Error copying test file %s to %s. Exception: %s', fs, path.http, err));
+        }
 
-        fs.readFile(path.fs, function (err, data) {
-          if (err) {
-            return;
-          }
+        var promise = when.defer().resolve();
 
-          instrumenter.instrument(data.toString(), path.fs, function (err, code) {
-            // Kind of hacky, need to make sure directory exists before writing
-            // TODO: clean this up
-            var p = path.http.split('/').slice(0, -1).join('/');
-            mkdirp(p, function () {
-              fs.writeFile(path.http, code, function (err) {
-                if (err) {
-                  logger.error('Unable to write file: ' + path.http);
-                }
+        // Instrumentable code considered "source" code; can be transformed
+        if (path.instrumentable)
+          promise = this.executeHook('transform', path.fs);
+
+        // only instrument file for code coverage if option is enabled and file is an @venus-include
+        if (this.instrumentCodeCoverage && path.instrumentable) {
+          // instrument the file with istanbul
+          promise.then(function () {
+            instrumenter = new Instrumenter();
+
+            fs.readFile(path.http, function (err, data) {
+              if (err) {
+                return;
+              }
+
+              instrumenter.instrument(data.toString(), path.http, function (err, code) {
+                // Kind of hacky, need to make sure directory exists before writing
+                // TODO: clean this up
+                var p = path.http.split('/').slice(0, -1).join('/');
+                mkdirp(p, function () {
+                  fs.writeFile(path.http, code, function (err) {
+                    if (err) {
+                      logger.error('Unable to write file: ' + path.http);
+                    }
+                  });
+                });
               });
             });
           });
-        });
-      } else {
-        fstools.copy(path.fs, path.http, function(err) {
-          if (err) {
-            logger.debug(i18n('Error copying test file %s to %s. Exception: %s', path.fs, path.http, err));
-          }
-        });
+        }
+      }.bind(this));
 
-      }
-    }, this);
+    }.bind(this), this);
 
     return { urls: urls};
 };

--- a/test/data/sample_tests/execute/setup.js
+++ b/test/data/sample_tests/execute/setup.js
@@ -1,3 +1,7 @@
 module.exports.before = function () {
   return 'before hook';
 };
+
+module.exports.transform = function (ctx, target) {
+  return 'transform hook';
+}

--- a/test/unit/testcase.spec.js
+++ b/test/unit/testcase.spec.js
@@ -196,6 +196,7 @@ describe('lib/testcase', function () {
 
         expect(scripts.length).to.be(1);
         expect(scripts[0].before()).to.be('before hook');
+        expect(scripts[0].transform()).to.be('transform hook');
       });
     });
   });


### PR DESCRIPTION
This enables a new hook (via @venus-execute), "transform", that lets you pre-process files before they're instrumented and copied to the HTTP path.

An example use case would be to run the CoffeeScript transpiler on your source files, first.
