### PR TITLE
update express

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "license"          : "Apache 2.0",
   "dependencies"      : {
-    "express"                : "3.0.0beta4",
+    "express"                : "3.6.0",
     "socket.io"              : "0.8.7",
     "socket.io-client"       : "0.9.6",
     "colors"                 : "0.6.0",


### PR DESCRIPTION
Updating the express version fixes a `TypeError: Arguments to path.join must be strings` error for me, which I believe originates from a regression in earliers express versions.
