### PR TITLE
Fix #335

### DIFF
--- a/lib/reporters/JUnitReporter.js
+++ b/lib/reporters/JUnitReporter.js
@@ -23,6 +23,8 @@ var util         = require('util'),
  */
 function JUnitReporter(outputFile) {
   BaseReporter.call(this, outputFile);
+
+  this.suiteReports = [];
 }
 
 // We want to listen for events
@@ -33,6 +35,7 @@ util.inherits(JUnitReporter, BaseReporter);
  */
 JUnitReporter.prototype.onStart = function () {
   base.onSuite.call(this);
+
   this.log('<testsuites>');
 };
 
@@ -70,16 +73,10 @@ JUnitReporter.prototype.onEnd = function (testgroup, duration) {
  */
 JUnitReporter.prototype.onFileStart = function (test, agent) {
   base.onFileStart.call(this, test, agent);
-  this.log(
-    '<testsuite ',
-    'name="', this.clean(test.path), '" ',
-    'failures="', test.results.done.failed, '" ',
-    'tests="', test.results.done.total, '" ',
-    'time="', test.results.done.runtime, '"',
-    '>'
-   );
 
-    console.log('\n', agent, test.path);
+  this.suiteReports.push(
+    new JUnitSuiteReport(this, test.path)
+  );
 };
 
 /**
@@ -100,14 +97,9 @@ JUnitReporter.prototype.onTestEnd = function (results) {
   base.onTestEnd.call(this, results);
   var passed = (results.status === 'PASSED');
 
-  this.log(
-    '<testcase ',
-    'name=" >> ', this.clean(results.name), ' >> ', this.clean(results.message), '" ',
-    'classname="', results.file.replace(/\./g, '-'), '" ',
-    'result="', (passed) ? 'pass' : 'fail', '" ',
-    'message="', this.clean(results.message), '"',
-    (passed) ? '/>' : '>'
-  );
+  // Get active suite report (last in list)
+  var report = this.suiteReports[this.suiteReports.length - 1];
+  report.logTestResults(results);
 
   if (!passed) {
     this.log('<failure>');
@@ -162,11 +154,59 @@ JUnitReporter.prototype.onFail = function (name, message, stackTrace) {
  * @param {int} runtime - Number of miliseconds the suite took to run
  */
 JUnitReporter.prototype.onFileEnd = function (runtime) {
-
-  this.log('</testsuite>');
+  this.suiteReports.forEach(function (report) {
+    this.log(report.toString());
+  }, this);
 
   console.log('\r');
   base.onFileEnd.call(this, runtime);
+};
+
+
+/**
+ * Reports on a single suite
+ */
+function JUnitSuiteReport(reporter, path) {
+  this.reporter = reporter;
+  this.path = path;
+  this.testCaseResults = [];
+}
+
+/**
+ * Log the result of an individual test case
+ *
+ * @param {Object} results - Test results
+ */
+JUnitSuiteReport.prototype.logTestResults = function (results) {
+  this.testCaseResults.push(results);
+};
+
+/**
+ * Output the suite as an XML string for logging
+ */
+JUnitSuiteReport.prototype.toString = function () {
+  var reporter = this.reporter;
+  var clean = reporter.clean;
+
+  var out = [['  <testsuite ',
+    'name="', reporter.clean(this.path), '" ',
+    'failures="', reporter.failed, '" ',
+    'tests="', reporter.total, '" ',
+    'time="', reporter.runtime, '"',
+    '>'].join('')];
+
+  out = out.concat(this.testCaseResults.map(function (results) {
+    var passed = (results.status === 'PASSED');
+    return ['    <testcase ',
+        'name=" >> ', clean(results.name), ' >> ', clean(results.message), '" ',
+        'classname="', results.file.replace(/\./g, '-'), '" ',
+        'result="', passed ? 'pass' : 'fail', '" ',
+        'message="', clean(results.message), '"',
+        passed ? '/>' : '>'].join('');
+  }));
+
+  out.push('</testsuite>');
+  return out.join('\n');
 };
 
 module.exports = JUnitReporter;


### PR DESCRIPTION
Accumulates each test result in a `JUnitSuiteReport` instance, then logs the result when the suite is over.

This way, the correct total/fail values are output in the top-level `<testsuite>` element.