### PR TITLE
Fix phantomjs timeout issue 

### DIFF
--- a/lib/uac/GhostDriverUac.js
+++ b/lib/uac/GhostDriverUac.js
@@ -21,6 +21,7 @@
 
 var webdriver   = require('selenium-webdriver'),
     log         = require('../util/logger'),
+    portscanner = require('portscanner'),
     deferred    = require('deferred'),
     fsHelper    = require('../util/fsHelper'),
     spawn       = require('child_process').spawn,
@@ -31,20 +32,10 @@ var webdriver   = require('selenium-webdriver'),
  * @param {Object} options
  */
 function GhostDriverUac(options) {
-  this.host = options.host || 'http://localhast';
+  this.host = options.host || 'localhost';
   this.port = options.port || 8910;
 
-  this.server = [
-    this.host || 'http://localhost',
-    ':',
-    this.port
-  ].join('');
-
   this.startAttempts = 0;
-
-  if (this.server.indexOf('http://') !== 0) {
-    this.server = 'http://' + this.server;
-  }
 
   if (options && options.binaryPath) {
     this.binaryPath = fsHelper.getFirstValidPath(options.binaryPath);
@@ -67,11 +58,19 @@ GhostDriverUac.prototype.start = function () {
   // First, try to kill other phantomjs processes
   spawn('killall', ['-9', 'phantomjs']).on('exit', function () {
     // Now, go ahead and start a new phantomjs process
-    spawnPhantom.call(this);
+    portscanner.findAPortNotInUse(this.port,
+                                  this.port + 2000,
+                                  this.host,
+                                  function(err, port) {
+      this.port = port;
+      this.server = 'http://' + this.host + ':' + this.port;
+      log.debug('Trying to create PhontamJS Selenium server at', this.server);
+      spawnPhantom.call(this);
+    }.bind(this));
   }.bind(this));
 
   function spawnPhantom () {
-    this.process = spawn(binary, ['--webdriver=' + this.options.port]);
+    this.process = spawn(binary, ['--webdriver=' + this.port]);
     this.process.on('exit', function (code) {
 
       // Invalid phantomjs path


### PR DESCRIPTION
The venus will say "phantomjs timeout..." when there is already a phantomjs process stuck on the same port.

The "kill -9" command run before spawning the phantomjs did not solve the problem. This will try to start the phantomjs on a different port.