### PR TITLE
allowed for VenusTestList to be referenced in the proper window context

### DIFF
--- a/js/runner_client/VenusClientLibrary.js
+++ b/js/runner_client/VenusClientLibrary.js
@@ -56,10 +56,12 @@ VenusClientLibrary.prototype.done = function(results) {
 
   // decorate the test results with metadata
   results.userAgent = window.navigator.userAgent;
-  results.codeCoverageData  = sandbox.contentWindow.__coverage__;
+  results.codeCoverageData  = sandbox.contentWindow && sandbox.contentWindow.__coverage__;
   results.testId = window.venus.testId;
 
-  this.socket.emit('results', results);
+  if (this.socket) {
+    this.socket.emit('results', results);
+  }
 
   // append the test results to the document
   doneEl.id = 'test-done-marker';
@@ -67,8 +69,8 @@ VenusClientLibrary.prototype.done = function(results) {
 
   $(document).trigger('results', results);
 
-  if (window.VenusTestList) {
-    VenusTestList.postTestResults(results);
+  if (window.parent && window.parent.VenusTestList && window.parent.VenusTestList.postTestResults) {
+    window.parent.VenusTestList.postTestResults(results);
   }
 };
 

--- a/test/unit/client/.venus/config
+++ b/test/unit/client/.venus/config
@@ -1,5 +1,13 @@
 {
   basePaths: {
     'runnerClient': '../../../../js/runner_client'
+  },
+
+  includes: {
+    default: [
+      '../../../../js/jquery/jquery-1.10.0.min.js',
+      'mocks/venusTestList.js',
+      'mocks/venus.js'
+    ]
   }
 }

--- a/test/unit/client/.venus/mocks/venus.js
+++ b/test/unit/client/.venus/mocks/venus.js
@@ -1,0 +1,3 @@
+window.venus = window.venus || {
+  testId: 1
+};

--- a/test/unit/client/.venus/mocks/venusTestList.js
+++ b/test/unit/client/.venus/mocks/venusTestList.js
@@ -1,0 +1,3 @@
+window.parent.VenusTestList = window.parent.VenusTestList || {
+  postTestResults: function() {}
+};

--- a/test/unit/client/runner_client/VenusClientLibrary.fixture.html
+++ b/test/unit/client/runner_client/VenusClientLibrary.fixture.html
@@ -1,0 +1,1 @@
+<div id="sandbox"></div>

--- a/test/unit/client/runner_client/VenusClientLibrary.spec.js
+++ b/test/unit/client/runner_client/VenusClientLibrary.spec.js
@@ -1,17 +1,33 @@
 /**
+ * @venus-fixture VenusClientLibrary.fixture.html
  * @venus-code runnerClient/VenusClientLibrary.js
  */
 describe('VenusClientLibrary', function() {
+  function createInstance() {
+    return new VenusClientLibrary({
+      host: 'www.example.com',
+      port: 1234
+    });
+  }
+
   it('should expect on the window as VenusClientLibrary', function() {
     expect(window.VenusClientLibrary).to.be.ok();
   });
 
   it('should instantiate a new VenusClientLibrary object', function() {
-    var venusClientLibrary = new VenusClientLibrary({
-      host: 'www.example.com',
-      port: 1234
-    });
+    expect(createInstance()).to.be.a(VenusClientLibrary);
+  });
 
-    expect(venusClientLibrary).to.be.a(VenusClientLibrary);
+  describe('.done()', function() {
+    it('should execute VenusTestList.postTestReults from the parent context', sinon.test(function() {
+      var instance = createInstance(),
+          resultsStub = this.stub(window.parent.VenusTestList, 'postTestResults'),
+          results = {
+            band: 'Godspeed You! Black Emperor'
+          };
+
+      instance.done(results);
+      sinon.assert.calledWith(resultsStub, sinon.match(results));
+    }));
   });
 });


### PR DESCRIPTION
tightened up logic to make sure VenusClientLibrary.js is really working

adding venus related mocks

added mocks to default includes

added simple and silly fixture for VenusClientLibrary

added test to make sure VenusTestList.postTestReults is actually being called