### PR TITLE
Bubbles phantomJS errors to Venus.

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -70,22 +70,21 @@ Environment.prototype.start = function (testgroup) {
 
   start.then(function (uac) {
     testgroup.testArray.forEach(function (test) {
-      uac.loadUrl(test.url.run).then(
-        function () {
-          testRunCount++;
+      uac.loadUrl(test.url.run).then(function () {
+        testRunCount++;
 
-          if (testRunCount === testCount) {
-            def.resolve();
-          }
-        },
-        function (e) {
-          this.reporter.emit('error', e);
+        if (testRunCount === testCount) {
+          def.resolve();
+        }
+      },
+      function (e) {
+        this.reporter.emit('error', e);
 
-          testRunCount++;
-          if (testRunCount === testCount) {
-            def.resolve();
-          }
-        }.bind(this)
+        testRunCount++;
+        if (testRunCount === testCount) {
+          def.resolve();
+        }
+      }.bind(this)
       );
     }.bind(this));
   }.bind(this),

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -209,7 +209,6 @@ Executor.prototype.runTests = function () {
   var i, len, uacs;
 
   this.throttle = 10;
-
   uacs = this.uacs;
   i = this.uacQueueIndex,
   len = Math.min(uacs.length, i + this.throttle);
@@ -288,8 +287,7 @@ Executor.prototype.parseTestPaths = function(testPaths, testFilePaths) {
 
   testPaths.forEach(function (path) {
     var stat,
-    dirContents,
-    test;
+    dirContents;
 
     // Don't try to traverse .venus folder
     if (path.match(/^.*\/\.venus$/)) {
@@ -682,6 +680,11 @@ Executor.prototype.printResults = function (result) {
 
   if (!result.tests || !result.done) {
     return false;
+  }
+
+  if(result.tests && result.tests.length < 1){
+    logger.info(i18n('No Test Ran').red);
+    reporter.emit('error', '', i18n('Issue Processing Test'));
   }
 
   if (!reporter) {

--- a/lib/uac/GhostDriverUac.js
+++ b/lib/uac/GhostDriverUac.js
@@ -106,14 +106,14 @@ GhostDriverUac.prototype.start = function () {
     // Log phantomjs process stdout
     this.process.stdout.on('data', function (data) {
 
-      //Phantom Executes as expected, but there's an error with the pantom results.
+      //Phantom Executes as expected, but there's an error with the phantom results.
       //For example, loads page properly, but require dependency isnt accounted for.
       if (data.toString().match(/(ERROR)/) !== null) {
         stderr += data;
       } else {
         stdout += data;
       }
-    }.bind(this));
+    });
 
     // Log phantomjs process stderr
     this.process.stderr.on('data', function (data) {

--- a/lib/uac/GhostDriverUac.js
+++ b/lib/uac/GhostDriverUac.js
@@ -64,7 +64,7 @@ GhostDriverUac.prototype.start = function () {
                                   function(err, port) {
       this.port = port;
       this.server = 'http://' + this.host + ':' + this.port;
-      log.debug('Trying to create PhontamJS Selenium server at', this.server);
+      log.debug('Trying to create PhantomJS Selenium server at', this.server);
       spawnPhantom.call(this);
     }.bind(this));
   }.bind(this));
@@ -105,8 +105,15 @@ GhostDriverUac.prototype.start = function () {
 
     // Log phantomjs process stdout
     this.process.stdout.on('data', function (data) {
-      stdout += data;
-    });
+
+      //Phantom Executes as expected, but there's an error with the pantom results.
+      //For example, loads page properly, but require dependency isnt accounted for.
+      if (data.toString().match(/(ERROR)/) !== null) {
+        stderr += data;
+      } else {
+        stdout += data;
+      }
+    }.bind(this));
 
     // Log phantomjs process stderr
     this.process.stderr.on('data', function (data) {
@@ -204,9 +211,7 @@ GhostDriverUac.prototype.loadUrl = function (url) {
       def = deferred();
 
   browser.get(loadUrl).then(
-    function () {
-
-    },
+    function () {},
     function (e) {
       log.error(loadUrl + ': ' + e.message);
     }

--- a/locales/en.js
+++ b/locales/en.js
@@ -24,5 +24,8 @@
 	"Using environment ghost": "Using environment ghost",
 	"skipping invalid test file %s": "skipping invalid test file %s",
 	"Disabling hot reload because there are more than 5 tests loaded": "Disabling hot reload because there are more than 5 tests loaded",
-	"Error copying test file %s to %s. Exception: %s": "Error copying test file %s to %s. Exception: %s"
+	"Error copying test file %s to %s. Exception: %s": "Error copying test file %s to %s. Exception: %s",
+	"No Test Ran": "No Tests Ran. Check the console output for more information.",
+	"Ensures all other Venus processes are killed before starting": "Ensures all other Venus processes are killed before starting",
+	"Running demo": "Running demo"
 }

--- a/locales/pirate.js
+++ b/locales/pirate.js
@@ -158,7 +158,8 @@
 	"Using environment ie8": "Using environment ie8",
 	"Using environment ie7": "Using environment ie7",
 	"Use https": "Use https",
-	"The test file \"/Users/jasonbelmonti/Documents/Workspace/Development/Open_Source/venus.js/runner_client/\" could not be found": "The test file \"/Users/jasonbelmonti/Documents/Workspace/Development/Open_Source/venus.js/runner_client/\" could not be found",
-	"The test file \"/Users/jasonbelmonti/Documents/Workspace/Development/Open_Source/venus.js/runner_client\" could not be found": "The test file \"/Users/jasonbelmonti/Documents/Workspace/Development/Open_Source/venus.js/runner_client\" could not be found",
-	"VenusUi.spec.js: Includes specified in your annotations could not be found\n - ../polyfill/bind-polyfill.js\n": "VenusUi.spec.js: Includes specified in your annotations could not be found\n - ../polyfill/bind-polyfill.js\n"
-}
+	"VenusUi.spec.js: Includes specified in your annotations could not be found\n - ../polyfill/bind-polyfill.js\n": "VenusUi.spec.js: Includes specified in your annotations could not be found\n - ../polyfill/bind-polyfill.js\n",
+	"No Test Ran": "No Tests Ran. Check the console output for more information.",
+	"Issue Processing Test": "There was an issue processing your tests. This is commonly due to improperly loading an external module in your test.",
+	"There was an issue running your test.": "There was an issue running your test.",
+	}

--- a/test/unit/node/executor.socketio.spec.js
+++ b/test/unit/node/executor.socketio.spec.js
@@ -42,7 +42,7 @@ describe('lib/executor -- socket.io', function() {
 
     it('should handle valid data', function(done) {
       // valid result data
-      socket.emit('results', { tests: [], done: { failed: 0, passed: 0, runtime: 0 }, userAgent: 'foo browser' }, function(response) {
+      socket.emit('results', { tests: ['something'], done: { failed: 0, passed: 0, runtime: 0 }, userAgent: 'foo browser' }, function(response) {
         expect(response.status).to.be('ok');
         done();
       });


### PR DESCRIPTION
**BUG**: Broken Test Files (IE: Require dependency, error in initial script load, anything that breaks the page in Phantom before tests actually start running) are skipped, with Venus accepting `0 passed, 0 failed.`

This fix increments the error count if that should happen, and prints the stacktrace to the console.
