### PR TITLE
fix for bug #309

### DIFF
--- a/Venus.js
+++ b/Venus.js
@@ -19,45 +19,19 @@
  * The Venus application code that is called by the Venus shell script (bin/venus).
  * @file
  */
-var Module        = require('module'),
-    actualRequire = Module.prototype.require;
 
-/*
- * The following call to graceful-fs is needed so that require('fs') inside it
- * will refer to the original fs module.
- */
-require('graceful-fs');
-
-/*
- * Overriding module.require to make sure require('fs') returns graceful-fs.
- * Require of a module other than fs will return the same module.
- *
- * TODO: remove this either by removing fs-tools or by making sure fs-tools make use of graceful-fs
- */
-Module.prototype.require = function(id) {
-  var module;
-
-  if (id === 'fs') {
-    module = actualRequire.call(this, 'graceful-fs');
-  } else {
-    module = actualRequire.apply(this, arguments);
-  }
-
-  return module;
-};
-
-var _             = require('underscore'),
-    fs            = require('fs'),
-    executor      = require('./lib/executor'),
-    i18n          = require('./lib/util/i18n'),
-    locale        = require('./lib/util/locale'),
-    logger        = require('./lib/util/logger'),
-    program       = require('commander'),
-    prompt        = require('cli-prompt'),
-    wrench        = require('wrench'),
-    path          = require('path'),
-    deferred      = require('deferred'),
-    ps            = require('./lib/util/ps');
+var _         = require('underscore'),
+    executor  = require('./lib/executor'),
+    i18n      = require('./lib/util/i18n'),
+    locale    = require('./lib/util/locale'),
+    logger    = require('./lib/util/logger'),
+    program   = require('commander'),
+    prompt    = require('cli-prompt'),
+    wrench    = require('wrench'),
+    fs        = require('fs'),
+    path      = require('path'),
+    deferred  = require('deferred'),
+    ps        = require('./lib/util/ps');
 
 /**
  * The Venus application object

--- a/Venus.js
+++ b/Venus.js
@@ -19,19 +19,45 @@
  * The Venus application code that is called by the Venus shell script (bin/venus).
  * @file
  */
+var Module        = require('module'),
+    actualRequire = Module.prototype.require;
 
-var _         = require('underscore'),
-    executor  = require('./lib/executor'),
-    i18n      = require('./lib/util/i18n'),
-    locale    = require('./lib/util/locale'),
-    logger    = require('./lib/util/logger'),
-    program   = require('commander'),
-    prompt    = require('cli-prompt'),
-    wrench    = require('wrench'),
-    fs        = require('fs'),
-    path      = require('path'),
-    deferred  = require('deferred'),
-    ps        = require('./lib/util/ps');
+/*
+ * The following call to graceful-fs is needed so that require('fs') inside it
+ * will refer to the original fs module.
+ */
+require('graceful-fs');
+
+/*
+ * Overriding module.require to make sure require('fs') returns graceful-fs.
+ * Require of a module other than fs will return the same module.
+ *
+ * TODO: remove this either by removing fs-tools or by making sure fs-tools make use of graceful-fs
+ */
+Module.prototype.require = function(id) {
+  var module;
+
+  if (id === 'fs') {
+    module = actualRequire.call(this, 'graceful-fs');
+  } else {
+    module = actualRequire.apply(this, arguments);
+  }
+
+  return module;
+};
+
+var _             = require('underscore'),
+    fs            = require('fs'),
+    executor      = require('./lib/executor'),
+    i18n          = require('./lib/util/i18n'),
+    locale        = require('./lib/util/locale'),
+    logger        = require('./lib/util/logger'),
+    program       = require('commander'),
+    prompt        = require('cli-prompt'),
+    wrench        = require('wrench'),
+    path          = require('path'),
+    deferred      = require('deferred'),
+    ps            = require('./lib/util/ps');
 
 /**
  * The Venus application object

--- a/js/runner_client/VenusUi.js
+++ b/js/runner_client/VenusUi.js
@@ -58,7 +58,9 @@ function VenusUi(config) {
     self.showSandbox();
   });
 
-  $(document).on(self._events.RESULTS, self.onResults.bind(this));
+  $(document).on(self._events.RESULTS, function() {
+    self.onResults.apply(self, arguments);
+  });
 }
 
 /**

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -19,16 +19,11 @@
 
 'use strict';
 var configHelper = require('./config'),
-    deferred     = require('deferred'),
-    i18n         = require('./util/i18n'),
-    logger       = require('./util/logger');
+    deferred     = require('deferred');
 
 /**
- * Stores environment configuration values
+ * Constructor
  * @constructor
- * @param {Object} config   a venus configuration object
- * @param {string} envName  the name of the environment
- * @param {Object} reporter an object that conforms to venus' reporting API
  */
 function Environment(config, envName, reporter) {
   this.config = config;
@@ -38,7 +33,7 @@ function Environment(config, envName, reporter) {
 
 /**
  * Initialize this instance
- * @param {String} envName the environment name
+ * @param {string} envName the environment name
  */
 Environment.prototype.init = function () {
   this.envConfig = this.loadConfig(this.envName);
@@ -47,8 +42,8 @@ Environment.prototype.init = function () {
 
 /**
  * Load environment config
- * @param  {String} envName the environment name
- * @return {Object}         the environment config object
+ * @param {string} envName the environment name
+ * @return {object} the environment config object
  */
 Environment.prototype.loadConfig = function (envName) {
   var envConfig = this.config.get('environments', envName);
@@ -63,9 +58,7 @@ Environment.prototype.loadConfig = function (envName) {
 };
 
 /**
- * Starts the environment
- * @param  {Object}  testgroup object containing tests (in tesgroup.testarray)
- * @return {Promise}           a promise that is resolved when all tests have completed execution
+ * Start the environment
  */
 Environment.prototype.start = function (testgroup) {
   var start = this.uac.start(),
@@ -73,37 +66,26 @@ Environment.prototype.start = function (testgroup) {
       testRunCount = 0,
       testCount = testgroup.testArray.length;
 
-  function onSuccess () {
-    testRunCount++;
-
-    if (testRunCount === testCount) {
-      def.resolve();
-    }
-  }
-
-  function onFail (err) {
-    this.reporter.emit('error', err);
-
-    testRunCount++;
-    if (testRunCount === testCount) {
-      def.resolve();
-    }
-  }
-
   this.pendingTests = testCount;
 
   start.then(function (uac) {
     testgroup.testArray.forEach(function (test) {
-      test.copyDependenciesPromise.then(function () {
-        uac.loadUrl(test.url.run).then(
-          onSuccess,
-          onFail.bind(this)
-        );
-      }.bind(this),
-      function (err) {
-        onFail.call(this, err);
-        logger.error(i18n('Failed to load url %s due to the dependencies not being copied', test.url.run));
-      }.bind(this));
+      uac.loadUrl(test.url.run).then(function () {
+        testRunCount++;
+
+        if (testRunCount === testCount) {
+          def.resolve();
+        }
+      },
+      function (e) {
+        this.reporter.emit('error', e);
+
+        testRunCount++;
+        if (testRunCount === testCount) {
+          def.resolve();
+        }
+      }.bind(this)
+      );
     }.bind(this));
   }.bind(this),
   def.reject);
@@ -112,8 +94,7 @@ Environment.prototype.start = function (testgroup) {
 };
 
 /**
- * Shuts down the environment
- * @return {Promise} a promise that is resolved when the user account control has finished its exit process
+ * Shutdown the environment
  */
 Environment.prototype.shutdown = function () {
   return this.uac.stop();
@@ -121,10 +102,10 @@ Environment.prototype.shutdown = function () {
 
 /**
  * Create a new instance
- * @param  {Object} config a venus config object
- * @param  {String} envName the environment name
- * @param  {Object} reporter the test reporter
- * @return {Object} the environment instance
+ * @param {object} config a venus config object
+ * @param {string} envName the environment name
+ * @param {object} reporter the test reporter
+ * @return {object} the environment instance
  */
 function create(config, envName, reporter) {
   return new Environment(config, envName, reporter).init();

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -19,11 +19,16 @@
 
 'use strict';
 var configHelper = require('./config'),
-    deferred     = require('deferred');
+    deferred     = require('deferred'),
+    i18n         = require('./util/i18n'),
+    logger       = require('./util/logger');
 
 /**
- * Constructor
+ * Stores environment configuration values
  * @constructor
+ * @param {Object} config   a venus configuration object
+ * @param {string} envName  the name of the environment
+ * @param {Object} reporter an object that conforms to venus' reporting API
  */
 function Environment(config, envName, reporter) {
   this.config = config;
@@ -33,7 +38,7 @@ function Environment(config, envName, reporter) {
 
 /**
  * Initialize this instance
- * @param {string} envName the environment name
+ * @param {String} envName the environment name
  */
 Environment.prototype.init = function () {
   this.envConfig = this.loadConfig(this.envName);
@@ -42,8 +47,8 @@ Environment.prototype.init = function () {
 
 /**
  * Load environment config
- * @param {string} envName the environment name
- * @return {object} the environment config object
+ * @param  {String} envName the environment name
+ * @return {Object}         the environment config object
  */
 Environment.prototype.loadConfig = function (envName) {
   var envConfig = this.config.get('environments', envName);
@@ -58,7 +63,9 @@ Environment.prototype.loadConfig = function (envName) {
 };
 
 /**
- * Start the environment
+ * Starts the environment
+ * @param  {Object}  testgroup object containing tests (in tesgroup.testarray)
+ * @return {Promise}           a promise that is resolved when all tests have completed execution
  */
 Environment.prototype.start = function (testgroup) {
   var start = this.uac.start(),
@@ -66,26 +73,37 @@ Environment.prototype.start = function (testgroup) {
       testRunCount = 0,
       testCount = testgroup.testArray.length;
 
+  function onSuccess () {
+    testRunCount++;
+
+    if (testRunCount === testCount) {
+      def.resolve();
+    }
+  }
+
+  function onFail (err) {
+    this.reporter.emit('error', err);
+
+    testRunCount++;
+    if (testRunCount === testCount) {
+      def.resolve();
+    }
+  }
+
   this.pendingTests = testCount;
 
   start.then(function (uac) {
     testgroup.testArray.forEach(function (test) {
-      uac.loadUrl(test.url.run).then(function () {
-        testRunCount++;
-
-        if (testRunCount === testCount) {
-          def.resolve();
-        }
-      },
-      function (e) {
-        this.reporter.emit('error', e);
-
-        testRunCount++;
-        if (testRunCount === testCount) {
-          def.resolve();
-        }
-      }.bind(this)
-      );
+      test.copyDependenciesPromise.then(function () {
+        uac.loadUrl(test.url.run).then(
+          onSuccess,
+          onFail.bind(this)
+        );
+      }.bind(this),
+      function (err) {
+        onFail.call(this, err);
+        logger.error(i18n('Failed to load url %s due to the dependencies not being copied', test.url.run));
+      }.bind(this));
     }.bind(this));
   }.bind(this),
   def.reject);
@@ -94,7 +112,8 @@ Environment.prototype.start = function (testgroup) {
 };
 
 /**
- * Shutdown the environment
+ * Shuts down the environment
+ * @return {Promise} a promise that is resolved when the user account control has finished its exit process
  */
 Environment.prototype.shutdown = function () {
   return this.uac.stop();
@@ -102,10 +121,10 @@ Environment.prototype.shutdown = function () {
 
 /**
  * Create a new instance
- * @param {object} config a venus config object
- * @param {string} envName the environment name
- * @param {object} reporter the test reporter
- * @return {object} the environment instance
+ * @param  {Object} config a venus config object
+ * @param  {String} envName the environment name
+ * @param  {Object} reporter the test reporter
+ * @return {Object} the environment instance
  */
 function create(config, envName, reporter) {
   return new Environment(config, envName, reporter).init();

--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -25,6 +25,7 @@ var fs           = require('fs'),
     logger       = require('./util/logger'),
     i18n         = require('./util/i18n'),
     constants    = require('./constants'),
+    deferred     = require('deferred'),
     pathm        = require('path'),
     configHelper = require('./config'),
     fstools      = require('fs-tools'),
@@ -48,12 +49,24 @@ var fs           = require('fs'),
       VENUS_EXECUTE: 'venus-execute'
     };
 
-// Constructor for TestCase
+/**
+ * Constructor
+ * @constructor
+ */
 function TestCase() {}
 
 util.inherits(TestCase, events.EventEmitter);
 
-// Initialize
+/**
+ * Initializes TestCase instance
+ * @param  {String}    path                   path to the test
+ * @param  {Number}    id                     the test's ID
+ * @param  {String}    runUrl                 the test's run URL (where it can be accessed via browser)
+ * @param  {String}    runPath                the test's runtime location (where it is served by express)
+ * @param  {Boolean}   instrumentCodeCoverage True to enable code coverage
+ * @param  {Boolean}   hotReload              Uses hot reload if true
+ * @return {Undefined}                        Undefined
+ */
 TestCase.prototype.init = function(path, id, runUrl, runPath, instrumentCodeCoverage, hotReload) {
   this.path                   = path;
   this.id                     = id;
@@ -63,8 +76,13 @@ TestCase.prototype.init = function(path, id, runUrl, runPath, instrumentCodeCove
   this.load();
 };
 
+/**
+ * Loads Venus information from test file
+ * @return {Undefined} Undefined
+ */
 TestCase.prototype.load = function () {
-  var testData  = this.parseTestFile(this.path);
+  var testData  = this.parseTestFile(this.path),
+      urls      = [];
 
   this.src                    = testData.src;
   this.directory              = testData.directory;
@@ -75,7 +93,13 @@ TestCase.prototype.load = function () {
   this.includes               = this.prepareIncludes(this.annotations);
   this.executeScripts         = this.prepareExecuteScripts(this.annotations);
   this.resources              = this.prepareResources(this.annotations);
-  this.url.includes           = this.copyFilesToHttpPath(this.includes).urls;
+  this.copyDependenciesPromise = this.copyFilesToHttpPath(this.includes);
+
+  this.includes.forEach(function (path) {
+    urls.push(path.url);
+  });
+
+  this.url.includes = urls;
 
   if (this.watcher) {
     this.watcher.close();
@@ -89,6 +113,11 @@ TestCase.prototype.load = function () {
 
 };
 
+/**
+ * Counts the number of Venus annotations in a file
+ * @param  {Object} annotations an object containing properties with keys equal to annotations (comment statements beginning with @venus)
+ * @return {Number}             the number of Venus annotations contained in the annotations object
+ */
 TestCase.prototype.countVenusAnnotations = function (annotations) {
   var count = 0;
 
@@ -102,7 +131,11 @@ TestCase.prototype.countVenusAnnotations = function (annotations) {
 
 };
 
-// Watch files
+/**
+ * Watch files for changes
+ * @param  {Array}     files an array of filepaths to watch
+ * @return {Undefined}       Undefined
+ */
 TestCase.prototype.watchFiles = function (files) {
   var watcher = this.watcher = require('chokidar').watch(files, {persistent: true});
 
@@ -122,8 +155,11 @@ TestCase.prototype.watchFiles = function (files) {
 };
 
 
-// Resolve annotations
-// Use default values for missing annotations
+/**
+ * Resolves annotations
+ * @param  {Object} annotations an object parsed from annotations contained in this testcase's test file
+ * @return {Object}             resolved annotations
+ */
 TestCase.prototype.resolveAnnotations = function(annotations) {
   var conf         = this.config,
       library      = annotations[annotation.VENUS_LIBRARY],
@@ -209,8 +245,12 @@ TestCase.prototype.getHttpRoot = function (testId) {
   return pathm.resolve(constants.userHome, '.venus_temp', 'test', testId.toString());
 };
 
-// Prepare testcase includes - there are the files
-// to be included on the test fixture page in the browser
+
+/**
+ * Prepare testcase includes - there are the files to be included on the test fixture page in the browser
+ * @param  {Object} annotations annotations object containing arrays of annotations
+ * @return {Array}              An array of filemappings that maps source files to files served from the temp location during test execution.
+ */
 TestCase.prototype.prepareIncludes = function (annotations) {
   var self = this,
       library = annotations[annotation.VENUS_LIBRARY],
@@ -355,7 +395,11 @@ TestCase.prototype.prepareIncludes = function (annotations) {
   return fileMappings;
 };
 
-// Prepare
+/**
+ * Prepares the code under test (the code to be executed) identified by @venus-execute annotations
+ * @param  {Object} annotations the annotations object parsed from annotations contained in this testcase's test file
+ * @return {Array}              an array of require-loaded modules
+ */
 TestCase.prototype.prepareExecuteScripts = function (annotations) {
   var scripts, modules;
 
@@ -379,7 +423,11 @@ TestCase.prototype.prepareExecuteScripts = function (annotations) {
   return modules;
 };
 
-// Execute scripts hook
+/**
+ * Executes hook functions
+ * @param  {String}  hook the name of the hook function to execute
+ * @return {Promise}      a promise that resolves when all script hook functions have resolved
+ */
 TestCase.prototype.executeHook = function (hook) {
   var ctx      = this.executeContext(),
       promises = [],
@@ -404,7 +452,10 @@ TestCase.prototype.executeHook = function (hook) {
   }
 };
 
-// Build execute context which is passed to execute scripts
+/**
+ * Build the execute context, which is passed to executeHook
+ * @return {Object} executionContext including testPath and testId properties
+ */
 TestCase.prototype.executeContext = function () {
   return {
     testPath: this.path,
@@ -412,9 +463,14 @@ TestCase.prototype.executeContext = function () {
   };
 };
 
-// Prepare testcase resources
-// There are external resources that are accessible within the sandbox
-// These are included via @venus-resource annotation
+
+/**
+ * Prepare testcase resources
+ * There are external resources that are accessible within the sandbox
+ * These are included via @venus-resource annotation
+ * @param  {Object} annotations an object containing properties with keys equal to annotations (comment statements beginning with @venus)
+ * @return {Array}              An array of filemappings that maps source files to files served from the temp location during test execution.
+ */
 TestCase.prototype.prepareResources = function (annotations) {
   var testId        = this.id,
       config        = this.config,
@@ -502,66 +558,94 @@ TestCase.prototype.prepareResources = function (annotations) {
   return fileMappings;
 };
 
-// Copy dependencies to http root
+/**
+ * Copy dependencies to http root temp location for serving tests via http
+ * @param  {Array} files an array of strings containing filepaths to be copied
+ * @return {Function}   A promise which get's resolved once all files get copied.
+ */
 TestCase.prototype.copyFilesToHttpPath = function (files) {
-    var urls = [], instrumenter;
+    var filesCopiedDeferredObj = deferred(),
+        dependenciesLoaded = 0,
+        totalDependencies = files.length,
+        instrumenter;
+
+    function onSuccess() {
+      if (totalDependencies === ++dependenciesLoaded) {
+        filesCopiedDeferredObj.resolve();
+      }
+    }
+
+    function onFail(err) {
+      filesCopiedDeferredObj.reject(err);
+    }
 
     files.forEach(function (path) {
-      // var symMkdirPath = path.http.replace(/\/(?:.(?!\/))+$/, '');
-      urls.push(path.url);
+      var promise;
 
       // Copy everything to http location; treat as "build" path
       fstools.copy(path.fs, path.http, function(err) {
         if (err) {
           logger.debug(i18n('Error copying test file %s to %s. Exception: %s', fs, path.http, err));
+          onFail(err);
         }
-
-        var promise = when.defer().resolve();
 
         // Instrumentable code considered "source" code; can be transformed
         if (path.instrumentable) {
           promise = this.executeHook('transform', path.http);
-        }
 
-        // only instrument file for code coverage if option is enabled and file is an @venus-include
-        if (this.instrumentCodeCoverage && path.instrumentable) {
-          // instrument the file with istanbul
-          promise.then(function () {
-            instrumenter = new Instrumenter({
-              preserveComments: true,
-              noCompact: true,
-              embedSource: true,
-              noAutoWrap: true
-            });
+          // only instrument file for code coverage if option is enabled and file is an @venus-include
+          if (this.instrumentCodeCoverage) {
+            // instrument the file with istanbul
+            promise.then(function () {
+              instrumenter = new Instrumenter({
+                preserveComments: true,
+                noCompact: true,
+                embedSource: true,
+                noAutoWrap: true
+              });
 
-            fs.readFile(path.http, function (err, data) {
-              if (err) {
-                return;
-              }
+              fs.readFile(path.http, function (err, data) {
+                if (err) {
+                  onFail(err);
+                  return;
+                }
 
-              instrumenter.instrument(data.toString(), path.http, function (err, code) {
-                // Kind of hacky, need to make sure directory exists before writing
-                // TODO: clean this up
-                var p = path.http.split('/').slice(0, -1).join('/');
-                mkdirp(p, function () {
-                  fs.writeFile(path.http, code, function (err) {
-                    if (err) {
-                      logger.error('Unable to write file: ' + path.http);
-                    }
+                instrumenter.instrument(data.toString(), path.http, function (err, code) {
+                  // Kind of hacky, need to make sure directory exists before writing
+                  // TODO: clean this up
+                  var p = path.http.split('/').slice(0, -1).join('/');
+                  mkdirp(p, function () {
+                    fs.writeFile(path.http, code, function (err) {
+                      if (err) {
+                        logger.error('Unable to write file: ' + path.http);
+                        onFail(err);
+                      }
+                      onSuccess();
+                    });
                   });
                 });
               });
+            }, function(err) {
+              onFail(err);
             });
-          });
+          } else {
+            onSuccess();
+          }
+        } else {
+          onSuccess();
         }
       }.bind(this));
 
     }.bind(this), this);
 
-    return { urls: urls};
+    return filesCopiedDeferredObj.promise;
 };
 
-// Load test harness template
+/**
+ * Load harness template
+ * @param  {Object} annotations an object containing properties with keys equal to annotations (comment statements beginning with @venus)
+ * @return {String}             template contents
+ */
 TestCase.prototype.loadHarnessTemplate = function(annotations) {
   var harnessName = annotations[annotation.VENUS_TEMPLATE];
 
@@ -574,7 +658,17 @@ TestCase.prototype.loadHarnessTemplate = function(annotations) {
   }
 };
 
-// Parse a test case file
+/**
+ * Parse a TestCase file
+ * @param  {String} file the path to the TestCase file
+ * @return {Object}      an object containing test file properties
+ * {
+ *   'path': The path to the TestCase file,
+ *   'directory': The directory containing this file,
+ *   'src': The file contents,
+ *   'annotations': The @venus- annotations contained in the file
+ * }
+ */
 TestCase.prototype.parseTestFile = function(file) {
   var fileContents = fs.readFileSync(file).toString();
 
@@ -589,7 +683,7 @@ TestCase.prototype.parseTestFile = function(file) {
 /**
  * Create a new TestCase object
  *
- * @param {object} config - Configuration object.
+ * @param {Object} config Configuration object.
  * {
  *  'config': Mandatory. Config file to use for this test
  *  'path': Mandatory. Path to the file that we are going to test
@@ -598,7 +692,7 @@ TestCase.prototype.parseTestFile = function(file) {
  *  'instrumentCodeCoverate': Boolean. True to enable code coverage
  * }
  *
- * @returns {object} instance - Instance of TestCase
+ * @returns {Object} instance Instance of TestCase
  */
 function create(config) {
   var instance = new TestCase();
@@ -609,8 +703,8 @@ function create(config) {
 
 /**
  * Parse a test file to see if it has annotations
- * @param {string} testPath - path to test file on disk
- * @returns {boolean}
+ * @param   {String}  testPath - path to test file on disk
+ * @returns {Boolean}
  */
 function hasAnnotations(testPath) {
   var test     = new TestCase(),

--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -25,6 +25,7 @@ var fs           = require('fs'),
     logger       = require('./util/logger'),
     i18n         = require('./util/i18n'),
     constants    = require('./constants'),
+    deferred     = require('deferred'),
     pathm        = require('path'),
     configHelper = require('./config'),
     fstools      = require('fs-tools'),
@@ -48,12 +49,24 @@ var fs           = require('fs'),
       VENUS_EXECUTE: 'venus-execute'
     };
 
-// Constructor for TestCase
+/**
+ * Constructor
+ * @constructor
+ */
 function TestCase() {}
 
 util.inherits(TestCase, events.EventEmitter);
 
-// Initialize
+/**
+ * Initializes TestCase instance
+ * @param  {String}    path                   path to the test
+ * @param  {Number}    id                     the test's ID
+ * @param  {String}    runUrl                 the test's run URL (where it can be accessed via browser)
+ * @param  {String}    runPath                the test's runtime location (where it is served by express)
+ * @param  {Boolean}   instrumentCodeCoverage True to enable code coverage
+ * @param  {Boolean}   hotReload              Uses hot reload if true
+ * @return {Undefined}                        Undefined
+ */
 TestCase.prototype.init = function(path, id, runUrl, runPath, instrumentCodeCoverage, hotReload) {
   this.path                   = path;
   this.id                     = id;
@@ -63,8 +76,13 @@ TestCase.prototype.init = function(path, id, runUrl, runPath, instrumentCodeCove
   this.load();
 };
 
+/**
+ * Loads Venus information from test file
+ * @return {Undefined} Undefined
+ */
 TestCase.prototype.load = function () {
-  var testData  = this.parseTestFile(this.path);
+  var testData  = this.parseTestFile(this.path),
+      urls      = [];
 
   this.src                    = testData.src;
   this.directory              = testData.directory;
@@ -75,7 +93,13 @@ TestCase.prototype.load = function () {
   this.includes               = this.prepareIncludes(this.annotations);
   this.executeScripts         = this.prepareExecuteScripts(this.annotations);
   this.resources              = this.prepareResources(this.annotations);
-  this.url.includes           = this.copyFilesToHttpPath(this.includes).urls;
+  this.copyDependenciesPromise = this.copyFilesToHttpPath(this.includes);
+
+  this.includes.forEach(function (path) {
+    urls.push(path.url);
+  });
+
+  this.url.includes = urls;
 
   if (this.watcher) {
     this.watcher.close();
@@ -89,6 +113,11 @@ TestCase.prototype.load = function () {
 
 };
 
+/**
+ * Counts the number of Venus annotations in a file
+ * @param  {Object} annotations an object containing properties with keys equal to annotations (comment statements beginning with @venus)
+ * @return {Number}             the number of Venus annotations contained in the annotations object
+ */
 TestCase.prototype.countVenusAnnotations = function (annotations) {
   var count = 0;
 
@@ -102,7 +131,11 @@ TestCase.prototype.countVenusAnnotations = function (annotations) {
 
 };
 
-// Watch files
+/**
+ * Watch files for changes
+ * @param  {Array}     files an array of filepaths to watch
+ * @return {Undefined}       Undefined
+ */
 TestCase.prototype.watchFiles = function (files) {
   var watcher = this.watcher = require('chokidar').watch(files, {persistent: true});
 
@@ -122,8 +155,11 @@ TestCase.prototype.watchFiles = function (files) {
 };
 
 
-// Resolve annotations
-// Use default values for missing annotations
+/**
+ * Resolves annotations
+ * @param  {Object} annotations an object parsed from annotations contained in this testcase's test file
+ * @return {Object}             resolved annotations
+ */
 TestCase.prototype.resolveAnnotations = function(annotations) {
   var conf         = this.config,
       library      = annotations[annotation.VENUS_LIBRARY],
@@ -209,8 +245,12 @@ TestCase.prototype.getHttpRoot = function (testId) {
   return pathm.resolve(constants.userHome, '.venus_temp', 'test', testId.toString());
 };
 
-// Prepare testcase includes - there are the files
-// to be included on the test fixture page in the browser
+
+/**
+ * Prepare testcase includes - there are the files to be included on the test fixture page in the browser
+ * @param  {Object} annotations annotations object containing arrays of annotations
+ * @return {Array}              An array of filemappings that maps source files to files served from the temp location during test execution.
+ */
 TestCase.prototype.prepareIncludes = function (annotations) {
   var self = this,
       library = annotations[annotation.VENUS_LIBRARY],
@@ -355,7 +395,11 @@ TestCase.prototype.prepareIncludes = function (annotations) {
   return fileMappings;
 };
 
-// Prepare
+/**
+ * Prepares the code under test (the code to be executed) identified by @venus-execute annotations
+ * @param  {Object} annotations the annotations object parsed from annotations contained in this testcase's test file
+ * @return {Array}              an array of require-loaded modules
+ */
 TestCase.prototype.prepareExecuteScripts = function (annotations) {
   var scripts, modules;
 
@@ -379,7 +423,11 @@ TestCase.prototype.prepareExecuteScripts = function (annotations) {
   return modules;
 };
 
-// Execute scripts hook
+/**
+ * Executes hook functions
+ * @param  {String}  hook the name of the hook function to execute
+ * @return {Promise}      a promise that resolves when all script hook functions have resolved
+ */
 TestCase.prototype.executeHook = function (hook) {
   var ctx      = this.executeContext(),
       promises = [],
@@ -404,7 +452,10 @@ TestCase.prototype.executeHook = function (hook) {
   }
 };
 
-// Build execute context which is passed to execute scripts
+/**
+ * Build the execute context, which is passed to executeHook
+ * @return {Object} executionContext including testPath and testId properties
+ */
 TestCase.prototype.executeContext = function () {
   return {
     testPath: this.path,
@@ -412,9 +463,14 @@ TestCase.prototype.executeContext = function () {
   };
 };
 
-// Prepare testcase resources
-// There are external resources that are accessible within the sandbox
-// These are included via @venus-resource annotation
+
+/**
+ * Prepare testcase resources
+ * There are external resources that are accessible within the sandbox
+ * These are included via @venus-resource annotation
+ * @param  {Object} annotations an object containing properties with keys equal to annotations (comment statements beginning with @venus)
+ * @return {Array}              An array of filemappings that maps source files to files served from the temp location during test execution.
+ */
 TestCase.prototype.prepareResources = function (annotations) {
   var testId        = this.id,
       config        = this.config,
@@ -502,66 +558,92 @@ TestCase.prototype.prepareResources = function (annotations) {
   return fileMappings;
 };
 
-// Copy dependencies to http root
+/**
+ * Copy dependencies to http root temp location for serving tests via http
+ * @param  {Array} files an array of strings containing filepaths to be copied
+ * @return {Function}   A promise which get's resolved once all files get copied.
+ */
 TestCase.prototype.copyFilesToHttpPath = function (files) {
-    var urls = [], instrumenter;
+    var filesCopiedDeferredObj = deferred(),
+        dependenciesLoaded = 0,
+        totalDependencies = files.length,
+        instrumenter;
+
+    function onSuccess() {
+      if (totalDependencies === ++dependenciesLoaded) {
+        filesCopiedDeferredObj.resolve();
+      }
+    }
+
+    function onFail(err) {
+      filesCopiedDeferredObj.reject(err);
+    }
 
     files.forEach(function (path) {
-      // var symMkdirPath = path.http.replace(/\/(?:.(?!\/))+$/, '');
-      urls.push(path.url);
+      var promise;
 
       // Copy everything to http location; treat as "build" path
       fstools.copy(path.fs, path.http, function(err) {
         if (err) {
           logger.debug(i18n('Error copying test file %s to %s. Exception: %s', fs, path.http, err));
+          onFail(err);
         }
-
-        var promise = when.defer().resolve();
 
         // Instrumentable code considered "source" code; can be transformed
         if (path.instrumentable) {
           promise = this.executeHook('transform', path.http);
-        }
 
-        // only instrument file for code coverage if option is enabled and file is an @venus-include
-        if (this.instrumentCodeCoverage && path.instrumentable) {
-          // instrument the file with istanbul
-          promise.then(function () {
-            instrumenter = new Instrumenter({
-              preserveComments: true,
-              noCompact: true,
-              embedSource: true,
-              noAutoWrap: true
-            });
+          // only instrument file for code coverage if option is enabled and file is an @venus-include
+          if (this.instrumentCodeCoverage) {
+            // instrument the file with istanbul
+            promise.then(function () {
+              instrumenter = new Instrumenter({
+                preserveComments: true,
+                noCompact: true,
+                embedSource: true,
+                noAutoWrap: true
+              });
 
-            fs.readFile(path.http, function (err, data) {
-              if (err) {
-                return;
-              }
+              fs.readFile(path.http, function (err, data) {
+                if (err) {
+                  onFail(err);
+                  return;
+                }
 
-              instrumenter.instrument(data.toString(), path.http, function (err, code) {
-                // Kind of hacky, need to make sure directory exists before writing
-                // TODO: clean this up
-                var p = path.http.split('/').slice(0, -1).join('/');
-                mkdirp(p, function () {
-                  fs.writeFile(path.http, code, function (err) {
-                    if (err) {
-                      logger.error('Unable to write file: ' + path.http);
-                    }
+                instrumenter.instrument(data.toString(), path.http, function (err, code) {
+                  // Kind of hacky, need to make sure directory exists before writing
+                  // TODO: clean this up
+                  var p = path.http.split('/').slice(0, -1).join('/');
+                  mkdirp(p, function () {
+                    fs.writeFile(path.http, code, function (err) {
+                      if (err) {
+                        logger.error('Unable to write file: ' + path.http);
+                        onFail(err);
+                      }
+                      onSuccess();
+                    });
                   });
                 });
               });
+            }, function(err) {
+              onFail(err);
             });
-          });
+          }
+        } else {
+          onSuccess();
         }
       }.bind(this));
 
     }.bind(this), this);
 
-    return { urls: urls};
+    return filesCopiedDeferredObj.promise;
 };
 
-// Load test harness template
+/**
+ * Load harness template
+ * @param  {Object} annotations an object containing properties with keys equal to annotations (comment statements beginning with @venus)
+ * @return {String}             template contents
+ */
 TestCase.prototype.loadHarnessTemplate = function(annotations) {
   var harnessName = annotations[annotation.VENUS_TEMPLATE];
 
@@ -574,7 +656,17 @@ TestCase.prototype.loadHarnessTemplate = function(annotations) {
   }
 };
 
-// Parse a test case file
+/**
+ * Parse a TestCase file
+ * @param  {String} file the path to the TestCase file
+ * @return {Object}      an object containing test file properties
+ * {
+ *   'path': The path to the TestCase file,
+ *   'directory': The directory containing this file,
+ *   'src': The file contents,
+ *   'annotations': The @venus- annotations contained in the file
+ * }
+ */
 TestCase.prototype.parseTestFile = function(file) {
   var fileContents = fs.readFileSync(file).toString();
 
@@ -589,7 +681,7 @@ TestCase.prototype.parseTestFile = function(file) {
 /**
  * Create a new TestCase object
  *
- * @param {object} config - Configuration object.
+ * @param {Object} config Configuration object.
  * {
  *  'config': Mandatory. Config file to use for this test
  *  'path': Mandatory. Path to the file that we are going to test
@@ -598,7 +690,7 @@ TestCase.prototype.parseTestFile = function(file) {
  *  'instrumentCodeCoverate': Boolean. True to enable code coverage
  * }
  *
- * @returns {object} instance - Instance of TestCase
+ * @returns {Object} instance Instance of TestCase
  */
 function create(config) {
   var instance = new TestCase();
@@ -609,8 +701,8 @@ function create(config) {
 
 /**
  * Parse a test file to see if it has annotations
- * @param {string} testPath - path to test file on disk
- * @returns {boolean}
+ * @param   {String}  testPath - path to test file on disk
+ * @returns {Boolean}
  */
 function hasAnnotations(testPath) {
   var test     = new TestCase(),

--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -25,7 +25,6 @@ var fs           = require('fs'),
     logger       = require('./util/logger'),
     i18n         = require('./util/i18n'),
     constants    = require('./constants'),
-    deferred     = require('deferred'),
     pathm        = require('path'),
     configHelper = require('./config'),
     fstools      = require('fs-tools'),
@@ -49,24 +48,12 @@ var fs           = require('fs'),
       VENUS_EXECUTE: 'venus-execute'
     };
 
-/**
- * Constructor
- * @constructor
- */
+// Constructor for TestCase
 function TestCase() {}
 
 util.inherits(TestCase, events.EventEmitter);
 
-/**
- * Initializes TestCase instance
- * @param  {String}    path                   path to the test
- * @param  {Number}    id                     the test's ID
- * @param  {String}    runUrl                 the test's run URL (where it can be accessed via browser)
- * @param  {String}    runPath                the test's runtime location (where it is served by express)
- * @param  {Boolean}   instrumentCodeCoverage True to enable code coverage
- * @param  {Boolean}   hotReload              Uses hot reload if true
- * @return {Undefined}                        Undefined
- */
+// Initialize
 TestCase.prototype.init = function(path, id, runUrl, runPath, instrumentCodeCoverage, hotReload) {
   this.path                   = path;
   this.id                     = id;
@@ -76,13 +63,8 @@ TestCase.prototype.init = function(path, id, runUrl, runPath, instrumentCodeCove
   this.load();
 };
 
-/**
- * Loads Venus information from test file
- * @return {Undefined} Undefined
- */
 TestCase.prototype.load = function () {
-  var testData  = this.parseTestFile(this.path),
-      urls      = [];
+  var testData  = this.parseTestFile(this.path);
 
   this.src                    = testData.src;
   this.directory              = testData.directory;
@@ -93,13 +75,7 @@ TestCase.prototype.load = function () {
   this.includes               = this.prepareIncludes(this.annotations);
   this.executeScripts         = this.prepareExecuteScripts(this.annotations);
   this.resources              = this.prepareResources(this.annotations);
-  this.copyDependenciesPromise = this.copyFilesToHttpPath(this.includes);
-
-  this.includes.forEach(function (path) {
-    urls.push(path.url);
-  });
-
-  this.url.includes = urls;
+  this.url.includes           = this.copyFilesToHttpPath(this.includes).urls;
 
   if (this.watcher) {
     this.watcher.close();
@@ -113,11 +89,6 @@ TestCase.prototype.load = function () {
 
 };
 
-/**
- * Counts the number of Venus annotations in a file
- * @param  {Object} annotations an object containing properties with keys equal to annotations (comment statements beginning with @venus)
- * @return {Number}             the number of Venus annotations contained in the annotations object
- */
 TestCase.prototype.countVenusAnnotations = function (annotations) {
   var count = 0;
 
@@ -131,11 +102,7 @@ TestCase.prototype.countVenusAnnotations = function (annotations) {
 
 };
 
-/**
- * Watch files for changes
- * @param  {Array}     files an array of filepaths to watch
- * @return {Undefined}       Undefined
- */
+// Watch files
 TestCase.prototype.watchFiles = function (files) {
   var watcher = this.watcher = require('chokidar').watch(files, {persistent: true});
 
@@ -155,11 +122,8 @@ TestCase.prototype.watchFiles = function (files) {
 };
 
 
-/**
- * Resolves annotations
- * @param  {Object} annotations an object parsed from annotations contained in this testcase's test file
- * @return {Object}             resolved annotations
- */
+// Resolve annotations
+// Use default values for missing annotations
 TestCase.prototype.resolveAnnotations = function(annotations) {
   var conf         = this.config,
       library      = annotations[annotation.VENUS_LIBRARY],
@@ -245,12 +209,8 @@ TestCase.prototype.getHttpRoot = function (testId) {
   return pathm.resolve(constants.userHome, '.venus_temp', 'test', testId.toString());
 };
 
-
-/**
- * Prepare testcase includes - there are the files to be included on the test fixture page in the browser
- * @param  {Object} annotations annotations object containing arrays of annotations
- * @return {Array}              An array of filemappings that maps source files to files served from the temp location during test execution.
- */
+// Prepare testcase includes - there are the files
+// to be included on the test fixture page in the browser
 TestCase.prototype.prepareIncludes = function (annotations) {
   var self = this,
       library = annotations[annotation.VENUS_LIBRARY],
@@ -395,11 +355,7 @@ TestCase.prototype.prepareIncludes = function (annotations) {
   return fileMappings;
 };
 
-/**
- * Prepares the code under test (the code to be executed) identified by @venus-execute annotations
- * @param  {Object} annotations the annotations object parsed from annotations contained in this testcase's test file
- * @return {Array}              an array of require-loaded modules
- */
+// Prepare
 TestCase.prototype.prepareExecuteScripts = function (annotations) {
   var scripts, modules;
 
@@ -423,11 +379,7 @@ TestCase.prototype.prepareExecuteScripts = function (annotations) {
   return modules;
 };
 
-/**
- * Executes hook functions
- * @param  {String}  hook the name of the hook function to execute
- * @return {Promise}      a promise that resolves when all script hook functions have resolved
- */
+// Execute scripts hook
 TestCase.prototype.executeHook = function (hook) {
   var ctx      = this.executeContext(),
       promises = [],
@@ -452,10 +404,7 @@ TestCase.prototype.executeHook = function (hook) {
   }
 };
 
-/**
- * Build the execute context, which is passed to executeHook
- * @return {Object} executionContext including testPath and testId properties
- */
+// Build execute context which is passed to execute scripts
 TestCase.prototype.executeContext = function () {
   return {
     testPath: this.path,
@@ -463,14 +412,9 @@ TestCase.prototype.executeContext = function () {
   };
 };
 
-
-/**
- * Prepare testcase resources
- * There are external resources that are accessible within the sandbox
- * These are included via @venus-resource annotation
- * @param  {Object} annotations an object containing properties with keys equal to annotations (comment statements beginning with @venus)
- * @return {Array}              An array of filemappings that maps source files to files served from the temp location during test execution.
- */
+// Prepare testcase resources
+// There are external resources that are accessible within the sandbox
+// These are included via @venus-resource annotation
 TestCase.prototype.prepareResources = function (annotations) {
   var testId        = this.id,
       config        = this.config,
@@ -558,92 +502,66 @@ TestCase.prototype.prepareResources = function (annotations) {
   return fileMappings;
 };
 
-/**
- * Copy dependencies to http root temp location for serving tests via http
- * @param  {Array} files an array of strings containing filepaths to be copied
- * @return {Function}   A promise which get's resolved once all files get copied.
- */
+// Copy dependencies to http root
 TestCase.prototype.copyFilesToHttpPath = function (files) {
-    var filesCopiedDeferredObj = deferred(),
-        dependenciesLoaded = 0,
-        totalDependencies = files.length,
-        instrumenter;
-
-    function onSuccess() {
-      if (totalDependencies === ++dependenciesLoaded) {
-        filesCopiedDeferredObj.resolve();
-      }
-    }
-
-    function onFail(err) {
-      filesCopiedDeferredObj.reject(err);
-    }
+    var urls = [], instrumenter;
 
     files.forEach(function (path) {
-      var promise;
+      // var symMkdirPath = path.http.replace(/\/(?:.(?!\/))+$/, '');
+      urls.push(path.url);
 
       // Copy everything to http location; treat as "build" path
       fstools.copy(path.fs, path.http, function(err) {
         if (err) {
           logger.debug(i18n('Error copying test file %s to %s. Exception: %s', fs, path.http, err));
-          onFail(err);
         }
+
+        var promise = when.defer().resolve();
 
         // Instrumentable code considered "source" code; can be transformed
         if (path.instrumentable) {
           promise = this.executeHook('transform', path.http);
+        }
 
-          // only instrument file for code coverage if option is enabled and file is an @venus-include
-          if (this.instrumentCodeCoverage) {
-            // instrument the file with istanbul
-            promise.then(function () {
-              instrumenter = new Instrumenter({
-                preserveComments: true,
-                noCompact: true,
-                embedSource: true,
-                noAutoWrap: true
-              });
+        // only instrument file for code coverage if option is enabled and file is an @venus-include
+        if (this.instrumentCodeCoverage && path.instrumentable) {
+          // instrument the file with istanbul
+          promise.then(function () {
+            instrumenter = new Instrumenter({
+              preserveComments: true,
+              noCompact: true,
+              embedSource: true,
+              noAutoWrap: true
+            });
 
-              fs.readFile(path.http, function (err, data) {
-                if (err) {
-                  onFail(err);
-                  return;
-                }
+            fs.readFile(path.http, function (err, data) {
+              if (err) {
+                return;
+              }
 
-                instrumenter.instrument(data.toString(), path.http, function (err, code) {
-                  // Kind of hacky, need to make sure directory exists before writing
-                  // TODO: clean this up
-                  var p = path.http.split('/').slice(0, -1).join('/');
-                  mkdirp(p, function () {
-                    fs.writeFile(path.http, code, function (err) {
-                      if (err) {
-                        logger.error('Unable to write file: ' + path.http);
-                        onFail(err);
-                      }
-                      onSuccess();
-                    });
+              instrumenter.instrument(data.toString(), path.http, function (err, code) {
+                // Kind of hacky, need to make sure directory exists before writing
+                // TODO: clean this up
+                var p = path.http.split('/').slice(0, -1).join('/');
+                mkdirp(p, function () {
+                  fs.writeFile(path.http, code, function (err) {
+                    if (err) {
+                      logger.error('Unable to write file: ' + path.http);
+                    }
                   });
                 });
               });
-            }, function(err) {
-              onFail(err);
             });
-          }
-        } else {
-          onSuccess();
+          });
         }
       }.bind(this));
 
     }.bind(this), this);
 
-    return filesCopiedDeferredObj.promise;
+    return { urls: urls};
 };
 
-/**
- * Load harness template
- * @param  {Object} annotations an object containing properties with keys equal to annotations (comment statements beginning with @venus)
- * @return {String}             template contents
- */
+// Load test harness template
 TestCase.prototype.loadHarnessTemplate = function(annotations) {
   var harnessName = annotations[annotation.VENUS_TEMPLATE];
 
@@ -656,17 +574,7 @@ TestCase.prototype.loadHarnessTemplate = function(annotations) {
   }
 };
 
-/**
- * Parse a TestCase file
- * @param  {String} file the path to the TestCase file
- * @return {Object}      an object containing test file properties
- * {
- *   'path': The path to the TestCase file,
- *   'directory': The directory containing this file,
- *   'src': The file contents,
- *   'annotations': The @venus- annotations contained in the file
- * }
- */
+// Parse a test case file
 TestCase.prototype.parseTestFile = function(file) {
   var fileContents = fs.readFileSync(file).toString();
 
@@ -681,7 +589,7 @@ TestCase.prototype.parseTestFile = function(file) {
 /**
  * Create a new TestCase object
  *
- * @param {Object} config Configuration object.
+ * @param {object} config - Configuration object.
  * {
  *  'config': Mandatory. Config file to use for this test
  *  'path': Mandatory. Path to the file that we are going to test
@@ -690,7 +598,7 @@ TestCase.prototype.parseTestFile = function(file) {
  *  'instrumentCodeCoverate': Boolean. True to enable code coverage
  * }
  *
- * @returns {Object} instance Instance of TestCase
+ * @returns {object} instance - Instance of TestCase
  */
 function create(config) {
   var instance = new TestCase();
@@ -701,8 +609,8 @@ function create(config) {
 
 /**
  * Parse a test file to see if it has annotations
- * @param   {String}  testPath - path to test file on disk
- * @returns {Boolean}
+ * @param {string} testPath - path to test file on disk
+ * @returns {boolean}
  */
 function hasAnnotations(testPath) {
   var test     = new TestCase(),

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "istanbul": "0.3.4",
     "json5": "0.1.0",
     "mkdirp": "0.3.5",
+    "graceful-fs": "4.1.11",
     "phantomjs": "1.9.7-8",
     "portscanner": "0.1.3",
     "rmrf": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "istanbul": "0.3.4",
     "json5": "0.1.0",
     "mkdirp": "0.3.5",
-    "graceful-fs": "4.1.11",
     "phantomjs": "1.9.7-8",
     "portscanner": "0.1.3",
     "rmrf": "1.0.2",


### PR DESCRIPTION
when we run a large number of test cases, tests started failing as number of opened files hit the upper limit. To avoid it, i used graceful-fs so that it can auto retry after sometime. since we use fs-tools to work with files instead of 'fs' module, i need to override Module.prototype.require so that require('fs') returns 'graceful-fs' module.